### PR TITLE
Use Cargo's git authentication helper

### DIFF
--- a/src/repository/authentication.rs
+++ b/src/repository/authentication.rs
@@ -1,0 +1,219 @@
+//! Git authentication callbacks taken from upstream Cargo
+//!
+//! <https://github.com/rust-lang/cargo/blob/385b54b/src/cargo/sources/git/utils.rs#L409>
+
+use git2;
+use std::env;
+
+use error::{Error, ErrorKind};
+
+/// Prepare the authentication callbacks for cloning a git repository.
+///
+/// The main purpose of this function is to construct the "authentication
+/// callback" which is used to clone a repository. This callback will attempt to
+/// find the right authentication on the system (without user input) and will
+/// guide libgit2 in doing so.
+///
+/// The callback is provided `allowed` types of credentials, and we try to do as
+/// much as possible based on that:
+///
+/// * Prioritize SSH keys from the local ssh agent as they're likely the most
+///   reliable. The username here is prioritized from the credential
+///   callback, then from whatever is configured in git itself, and finally
+///   we fall back to the generic user of `git`.
+///
+/// * If a username/password is allowed, then we fallback to git2-rs's
+///   implementation of the credential helper. This is what is configured
+///   with `credential.helper` in git, and is the interface for the OSX
+///   keychain, for example.
+///
+/// * After the above two have failed, we just kinda grapple attempting to
+///   return *something*.
+///
+/// If any form of authentication fails, libgit2 will repeatedly ask us for
+/// credentials until we give it a reason to not do so. To ensure we don't
+/// just sit here looping forever we keep track of authentications we've
+/// attempted and we don't try the same ones again.
+pub(crate) fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F) -> Result<T, Error>
+where
+    F: FnMut(&mut git2::Credentials) -> Result<T, Error>,
+{
+    let mut cred_helper = git2::CredentialHelper::new(url);
+    cred_helper.config(cfg);
+
+    let mut ssh_username_requested = false;
+    let mut cred_helper_bad = None;
+    let mut ssh_agent_attempts = Vec::new();
+    let mut any_attempts = false;
+    let mut tried_sshkey = false;
+
+    let mut res = f(&mut |url, username, allowed| {
+        any_attempts = true;
+        // libgit2's "USERNAME" authentication actually means that it's just
+        // asking us for a username to keep going. This is currently only really
+        // used for SSH authentication and isn't really an authentication type.
+        // The logic currently looks like:
+        //
+        //      let user = ...;
+        //      if (user.is_null())
+        //          user = callback(USERNAME, null, ...);
+        //
+        //      callback(SSH_KEY, user, ...)
+        //
+        // So if we're being called here then we know that (a) we're using ssh
+        // authentication and (b) no username was specified in the URL that
+        // we're trying to clone. We need to guess an appropriate username here,
+        // but that may involve a few attempts. Unfortunately we can't switch
+        // usernames during one authentication session with libgit2, so to
+        // handle this we bail out of this authentication session after setting
+        // the flag `ssh_username_requested`, and then we handle this below.
+        if allowed.contains(git2::CredentialType::USERNAME) {
+            debug_assert!(username.is_none());
+            ssh_username_requested = true;
+            return Err(git2::Error::from_str("gonna try usernames later"));
+        }
+
+        // An "SSH_KEY" authentication indicates that we need some sort of SSH
+        // authentication. This can currently either come from the ssh-agent
+        // process or from a raw in-memory SSH key. Cargo only supports using
+        // ssh-agent currently.
+        //
+        // If we get called with this then the only way that should be possible
+        // is if a username is specified in the URL itself (e.g. `username` is
+        // Some), hence the unwrap() here. We try custom usernames down below.
+        if allowed.contains(git2::CredentialType::SSH_KEY) && !tried_sshkey {
+            // If ssh-agent authentication fails, libgit2 will keep
+            // calling this callback asking for other authentication
+            // methods to try. Make sure we only try ssh-agent once,
+            // to avoid looping forever.
+            tried_sshkey = true;
+            let username = username.unwrap();
+            debug_assert!(!ssh_username_requested);
+            ssh_agent_attempts.push(username.to_string());
+            return git2::Cred::ssh_key_from_agent(username);
+        }
+
+        // Sometimes libgit2 will ask for a username/password in plaintext. This
+        // is where Cargo would have an interactive prompt if we supported it,
+        // but we currently don't! Right now the only way we support fetching a
+        // plaintext password is through the `credential.helper` support, so
+        // fetch that here.
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) {
+            let r = git2::Cred::credential_helper(cfg, url, username);
+            cred_helper_bad = Some(r.is_err());
+            return r;
+        }
+
+        // I'm... not sure what the DEFAULT kind of authentication is, but seems
+        // easy to support?
+        if allowed.contains(git2::CredentialType::DEFAULT) {
+            return git2::Cred::default();
+        }
+
+        // Whelp, we tried our best
+        Err(git2::Error::from_str("no authentication available"))
+    });
+
+    // Ok, so if it looks like we're going to be doing ssh authentication, we
+    // want to try a few different usernames as one wasn't specified in the URL
+    // for us to use. In order, we'll try:
+    //
+    // * A credential helper's username for this URL, if available.
+    // * This account's username.
+    // * "git"
+    //
+    // We have to restart the authentication session each time (due to
+    // constraints in libssh2 I guess? maybe this is inherent to ssh?), so we
+    // call our callback, `f`, in a loop here.
+    if ssh_username_requested {
+        debug_assert!(res.is_err());
+        let mut attempts = Vec::new();
+        attempts.push("git".to_string());
+        if let Ok(s) = env::var("USER").or_else(|_| env::var("USERNAME")) {
+            attempts.push(s);
+        }
+        if let Some(ref s) = cred_helper.username {
+            attempts.push(s.clone());
+        }
+
+        while let Some(s) = attempts.pop() {
+            // We should get `USERNAME` first, where we just return our attempt,
+            // and then after that we should get `SSH_KEY`. If the first attempt
+            // fails we'll get called again, but we don't have another option so
+            // we bail out.
+            let mut attempts = 0;
+            res = f(&mut |_url, username, allowed| {
+                if allowed.contains(git2::CredentialType::USERNAME) {
+                    return git2::Cred::username(&s);
+                }
+                if allowed.contains(git2::CredentialType::SSH_KEY) {
+                    debug_assert_eq!(Some(&s[..]), username);
+                    attempts += 1;
+                    if attempts == 1 {
+                        ssh_agent_attempts.push(s.to_string());
+                        return git2::Cred::ssh_key_from_agent(&s);
+                    }
+                }
+                Err(git2::Error::from_str("no authentication available"))
+            });
+
+            // If we made two attempts then that means:
+            //
+            // 1. A username was requested, we returned `s`.
+            // 2. An ssh key was requested, we returned to look up `s` in the
+            //    ssh agent.
+            // 3. For whatever reason that lookup failed, so we were asked again
+            //    for another mode of authentication.
+            //
+            // Essentially, if `attempts == 2` then in theory the only error was
+            // that this username failed to authenticate (e.g. no other network
+            // errors happened). Otherwise something else is funny so we bail
+            // out.
+            if attempts != 2 {
+                break;
+            }
+        }
+    }
+
+    if res.is_ok() || !any_attempts {
+        return res.map_err(From::from);
+    }
+
+    // In the case of an authentication failure (where we tried something) then
+    // we try to give a more helpful error message about precisely what we
+    // tried.
+    let res = res.map_err(|_| {
+        let mut msg = "failed to authenticate when downloading repository".to_string();
+
+        if !ssh_agent_attempts.is_empty() {
+            let names = ssh_agent_attempts
+                .iter()
+                .map(|s| format!("`{}`", s))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            msg.push_str(&format!(
+                "\nattempted ssh-agent authentication, but none of the usernames {} succeeded",
+                names
+            ));
+        }
+
+        if let Some(failed_cred_helper) = cred_helper_bad {
+            if failed_cred_helper {
+                msg.push_str(
+                    "\nattempted to find username/password via git's \
+                     `credential.helper` support, but failed",
+                );
+            } else {
+                msg.push_str(
+                    "\nattempted to find username/password via `credential.helper`, \
+                     but maybe the found credentials were incorrect",
+                );
+            }
+        }
+
+        err!(ErrorKind::Repo, "{}", msg)
+    })?;
+
+    Ok(res)
+}

--- a/src/repository/commit.rs
+++ b/src/repository/commit.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
-use git2::ObjectType;
-#[cfg(feature = "chrono")]
-use git2::{Oid, ResetType};
+use git2;
 
 #[cfg(feature = "chrono")]
 use super::DAYS_UNTIL_STALE;
@@ -47,7 +45,7 @@ impl Commit {
         })?;
 
         let commit_id = oid.to_string();
-        let commit_object = repo.repo.find_object(oid, Some(ObjectType::Commit))?;
+        let commit_object = repo.repo.find_object(oid, Some(git2::ObjectType::Commit))?;
         let commit = commit_object.as_commit().unwrap();
         let author = commit.author().to_string();
 
@@ -87,12 +85,13 @@ impl Commit {
     #[cfg(feature = "chrono")]
     pub(crate) fn reset(&self, repo: &Repository) -> Result<(), Error> {
         let commit_object = repo.repo.find_object(
-            Oid::from_str(&self.commit_id).unwrap(),
-            Some(ObjectType::Commit),
+            git2::Oid::from_str(&self.commit_id).unwrap(),
+            Some(git2::ObjectType::Commit),
         )?;
 
         // Reset the state of the repository to the latest commit
-        repo.repo.reset(&commit_object, ResetType::Hard, None)?;
+        repo.repo
+            .reset(&commit_object, git2::ResetType::Hard, None)?;
 
         Ok(())
     }


### PR DESCRIPTION
Imports Cargo's upstream `with_authentication` function from:

https://github.com/rust-lang/cargo/blob/385b54b/src/cargo/sources/git/utils.rs#L409

This should address errors in scenarios where Git is not authenticated:

    authentication required but no callback set; class=Ssh (23)