### PR TITLE
README.md: Use backticks instead of "scare quotes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# "rustsec" crate: advisory DB client
+# `rustsec` crate: advisory DB client
 
 [![Latest Version][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]


### PR DESCRIPTION
Changes the header to use backticks