### PR TITLE
Handle cloning advisory DB into existing, empty dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ serde = "1"
 serde_derive = "1"
 toml = "0.4"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = ["chrono"]

--- a/src/db.rs
+++ b/src/db.rs
@@ -114,8 +114,7 @@ impl AdvisoryDatabase {
                     .patched_versions
                     .iter()
                     .any(|req| req.matches(version))
-            })
-            .map(|a| *a)
+            }).map(|a| *a)
             .collect()
     }
 

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -92,6 +92,14 @@ impl Repository {
             fail!(ErrorKind::BadParam, "invalid directory: {}", path.display())
         }
 
+        // Avoid libgit2 errors in the case the directory exists but is
+        // otherwise empty.
+        //
+        // See: https://github.com/RustSec/cargo-audit/issues/32
+        if path.is_dir() && fs::read_dir(&path)?.next().is_none() {
+            fs::remove_dir(&path)?;
+        }
+
         let git_config = git2::Config::new()?;
 
         with_authentication(url, &git_config, |f| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,16 @@
 extern crate rustsec;
 extern crate semver;
+extern crate tempfile;
 
-use rustsec::{AdvisoryDatabase, AdvisoryId, Lockfile, PackageName};
+use rustsec::{
+    AdvisoryDatabase, AdvisoryId, Lockfile, PackageName, Repository, ADVISORY_DB_REPO_URL,
+};
 use semver::VersionReq;
+use tempfile::tempdir;
 
-// End-to-end integration test (has online dependency on GitHub)
+/// End-to-end integration test (has online dependency on GitHub)
 #[test]
-fn test_integration() {
+fn happy_path() {
     let db = AdvisoryDatabase::fetch().unwrap();
     let example_advisory_id = AdvisoryId::new("RUSTSEC-2017-0001").unwrap();
     let example_advisory = db.find(&example_advisory_id).unwrap();
@@ -39,4 +43,14 @@ fn test_integration() {
     let lockfile = Lockfile::load("Cargo.lock").unwrap();
     let vulns = db.vulnerabilities(&lockfile);
     assert!(vulns.is_empty());
+}
+
+/// Regression test for cloning into an existing directory
+#[test]
+fn clone_into_existing_directory() {
+    // Make an empty temporary directory
+    let tmp = tempdir().unwrap();
+
+    // Attempt to fetch into it
+    Repository::fetch(ADVISORY_DB_REPO_URL, tmp.path(), true).unwrap();
 }


### PR DESCRIPTION
See: https://github.com/RustSec/cargo-audit/issues/32

This captures the issue in a test and resolves it by removing the directory if it already exists.