### PR TITLE
v0.9.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.9.2] (2018-10-14)
+
+[0.9.2]: https://github.com/RustSec/rustsec-crate/pull/48
+
+* [#47](https://github.com/RustSec/rustsec-crate/pull/47)
+  Handle cloning advisory DB into existing, empty dir.
+
 ## [0.9.1] (2018-07-29)
 
 [0.9.1]: https://github.com/RustSec/rustsec-crate/compare/v0.9.0...v0.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "rustsec"
 description   = "Client library for the RustSec security advisory database"
-version       = "0.9.1" # Also update html_root_url in lib.rs when bumping this
+version       = "0.9.2" # Also update html_root_url in lib.rs when bumping this
 authors       = ["Tony Arcieri <bascule@gmail.com>"]
 license       = "MIT OR Apache-2.0"
 homepage      = "https://github.com/rustsec/rustsec-crate/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.9.1"
+    html_root_url = "https://docs.rs/rustsec/0.9.2"
 )]
 
 #[cfg(feature = "chrono")]


### PR DESCRIPTION
[Diff from v0.9.1](https://github.com/RustSec/rustsec-crate/compare/v0.9.1...v0.9.2)

- #47 Handle cloning advisory DB into existing, empty dir.