### PR TITLE
Create parents of the advisory DB repo dir

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -86,7 +86,7 @@ impl Repository {
 
         if let Some(parent) = path.parent() {
             if !parent.is_dir() {
-                fail!(ErrorKind::BadParam, "not a directory: {}", parent.display());
+                fs::create_dir_all(parent)?;
             }
         } else {
             fail!(ErrorKind::BadParam, "invalid directory: {}", path.display())


### PR DESCRIPTION
...if they don't already exist. This fixes a cargo-audit issue:

https://github.com/RustSec/cargo-audit/issues/45