### PR TITLE
v0.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.9.3] (2018-10-14)
+
+[0.9.3]: https://github.com/RustSec/rustsec-crate/pull/50
+
+* [#49](https://github.com/RustSec/rustsec-crate/pull/49)
+  Handle cloning advisory DB into existing, empty dir.
+
 ## [0.9.2] (2018-10-14)
 
 [0.9.2]: https://github.com/RustSec/rustsec-crate/pull/48

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name          = "rustsec"
 description   = "Client library for the RustSec security advisory database"
-version       = "0.9.2" # Also update html_root_url in lib.rs when bumping this
+version       = "0.9.3" # Also update html_root_url in lib.rs when bumping this
 authors       = ["Tony Arcieri <bascule@gmail.com>"]
-license       = "MIT OR Apache-2.0"
+license       = "Apache-2.0 OR MIT"
 homepage      = "https://github.com/rustsec/rustsec-crate/"
 readme        = "README.md"
 categories    = ["api-bindings", "development-tools"]
-keywords      = ["rustsec", "security", "advisory", "vulnerability"]
+keywords      = ["audit", "rustsec", "security", "advisory", "vulnerability"]
 
 [dependencies]
 chrono = { version = "0.4", optional = true }
-directories = "1.0.1"
+directories = "1"
 failure = "0.1"
 failure_derive = "0.1"
 git2 = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.9.2"
+    html_root_url = "https://docs.rs/rustsec/0.9.3"
 )]
 
 #[cfg(feature = "chrono")]


### PR DESCRIPTION
[v0.9.3](https://github.com/RustSec/rustsec-crate/compare/v0.9.2...v0.9.3)

* #49 Handle cloning advisory DB into existing, empty dir.