### PR TITLE
Redo 'affected_functions' as 'affected_paths'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
 rust:
   - 1.31.0
   - stable
-  - beta
 
 os:
   - linux

--- a/src/advisory/mod.rs
+++ b/src/advisory/mod.rs
@@ -1,12 +1,12 @@
 //! Security advisories in the RustSec database
 
 mod date;
-mod function_path;
 mod id;
 mod iter;
 mod keyword;
+mod paths;
 
-pub use self::{date::*, function_path::FunctionPath, id::*, iter::Iter, keyword::Keyword};
+pub use self::{date::*, id::*, iter::Iter, keyword::Keyword, paths::AffectedPaths};
 use crate::package::PackageName;
 use platforms::target::{Arch, OS};
 use semver::VersionReq;
@@ -36,10 +36,12 @@ pub struct Advisory {
     /// Operating systems that this vulnerability is specific to
     pub affected_os: Option<Vec<OS>>,
 
-    /// Functions containing vulnerable code, enumerated as canonical Rust
-    /// paths (i.e. starting with the crate name), sans any path parameters.
+    /// Paths to types and/or functions containing vulnerable code, enumerated
+    /// as canonical Rust paths (i.e. starting with the crate name), sans any
+    /// path parameters.
+    ///
     /// (e.g. `mycrate::path::to::VulnerableStruct::vulnerable_func`)
-    pub affected_functions: Option<Vec<FunctionPath>>,
+    pub affected_paths: Option<AffectedPaths>,
 
     /// Advisory IDs in other databases which point to the same advisory
     #[serde(default)]


### PR DESCRIPTION
As discussed here:

https://github.com/RustSec/advisory-db/issues/68#issuecomment-449413588

This change collects paths (either functions or types) to code affected by an advisory, now parameterized by a `semver::VersionReq` as types may have been changed between versions, even if all versions are vulnerable.