### PR TITLE
v0.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.11.0] (2019-01-13)
+
+- Cargo.toml: Update `platforms` crate to v0.2 ([#59])
+- Redo advisory's `affected_functions` as `affected_paths` ([#58])
+
 ## [0.10.0] (2018-12-14)
 
 - Implement `affected_functions` advisory attribute ([#54])
@@ -92,6 +97,9 @@
 
 - Initial release
 
+[0.11.0]: https://github.com/RustSec/rustsec-crate/pull/60
+[#59]: https://github.com/RustSec/rustsec-crate/pull/58
+[#58]: https://github.com/RustSec/rustsec-crate/pull/59
 [0.10.0]: https://github.com/RustSec/rustsec-crate/pull/56
 [#54]: https://github.com/RustSec/rustsec-crate/pull/54
 [#53]: https://github.com/RustSec/rustsec-crate/pull/53

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/rustsec/rustsec-crate/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.10.0"
+    html_root_url = "https://docs.rs/rustsec/0.11.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Cargo.toml: Update `platforms` crate to v0.2 (#59)
- Redo advisory's `affected_functions` as `affected_paths` (#58)