### PR TITLE
Re-export all types in advisory::paths::*

### DIFF
--- a/src/advisory/mod.rs
+++ b/src/advisory/mod.rs
@@ -6,7 +6,7 @@ mod iter;
 mod keyword;
 mod paths;
 
-pub use self::{date::*, id::*, iter::Iter, keyword::Keyword, paths::AffectedPaths};
+pub use self::{date::*, id::*, iter::Iter, keyword::Keyword, paths::*};
 use crate::package::PackageName;
 use platforms::target::{Arch, OS};
 use semver::VersionReq;


### PR DESCRIPTION
There are several useful types in here for tooling which is trying to consume this data from advisories.

This makes it all public.