### PR TITLE
v0.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.12.0] (2019-07-15)
+
+- Update dependencies and use 2018 import conventions; Rust 1.32+ ([#64])
+- Re-export all types in `advisory::paths::*` ([#61])
+
 ## [0.11.0] (2019-01-13)
 
 - Cargo.toml: Update `platforms` crate to v0.2 ([#59])
@@ -97,6 +102,9 @@
 
 - Initial release
 
+[0.12.0]: https://github.com/RustSec/rustsec-crate/pull/65
+[#64]: https://github.com/RustSec/rustsec-crate/pull/64
+[#61]: https://github.com/RustSec/rustsec-crate/pull/61
 [0.11.0]: https://github.com/RustSec/rustsec-crate/pull/60
 [#59]: https://github.com/RustSec/rustsec-crate/pull/58
 [#58]: https://github.com/RustSec/rustsec-crate/pull/59

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/rustsec/rustsec-crate/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.11.0"
+    html_root_url = "https://docs.rs/rustsec/0.12.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Update dependencies and use 2018 import conventions; Rust 1.32+ (#64)
- Re-export all types in `advisory::paths::*` (#61)