### PR TITLE
Refactor advisory types: add [affected] and [versions] sections

### DIFF
--- a/src/advisory/date.rs
+++ b/src/advisory/date.rs
@@ -1,3 +1,5 @@
+//! Advisory dates
+
 use crate::error::{Error, ErrorKind};
 #[cfg(feature = "chrono")]
 use chrono::{self, DateTime, Utc};

--- a/src/advisory/info.rs
+++ b/src/advisory/info.rs
@@ -1,0 +1,57 @@
+//! Advisory information (i.e. the `[advisory]` section)
+
+use super::{date::Date, id::Id, keyword::Keyword};
+use crate::{package, version::VersionReq};
+use serde::{Deserialize, Serialize};
+
+/// The `[advisory]` section of a RustSec security advisory
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Info {
+    /// Security advisory ID (e.g. RUSTSEC-YYYY-NNNN)
+    pub id: Id,
+
+    /// Name of affected crate
+    pub package: package::Name,
+
+    /// Date this advisory was officially issued
+    pub date: Date,
+
+    /// Advisory IDs in other databases which point to the same advisory
+    #[serde(default)]
+    pub aliases: Vec<Id>,
+
+    /// CVSS v3.1 Base Metrics vector string containing severity information.
+    ///
+    /// Example:
+    ///
+    /// ```text
+    /// CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    /// ```
+    pub cvss: Option<cvss::v3::Base>,
+
+    /// Advisory IDs which are related to this advisory
+    #[serde(default)]
+    pub references: Vec<Id>,
+
+    /// Freeform keywords which succinctly describe this vulnerability (e.g. "ssl", "rce", "xss")
+    #[serde(default)]
+    pub keywords: Vec<Keyword>,
+
+    /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
+    pub url: Option<String>,
+
+    /// One-liner description of a vulnerability
+    pub title: String,
+
+    /// Extended description of a vulnerability
+    pub description: String,
+
+    /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
+    // TODO(tarcieri): phase this out
+    #[serde(default)]
+    pub(super) patched_versions: Vec<VersionReq>,
+
+    /// Versions which were never affected in the first place
+    #[serde(default)]
+    pub(super) unaffected_versions: Vec<VersionReq>,
+}

--- a/src/advisory/keyword.rs
+++ b/src/advisory/keyword.rs
@@ -1,3 +1,5 @@
+//! Advisory keywords
+
 use crate::error::Error;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
 use std::str::FromStr;

--- a/src/advisory/versions.rs
+++ b/src/advisory/versions.rs
@@ -1,0 +1,20 @@
+//! The `[versions]` subsection of an advisory.
+//!
+//! This is meant to eventually take the place of the `patched_versions`
+//! and `unaffected_versions` sections of the `[advisory]`, but can't be
+//! used
+
+use crate::version::VersionReq;
+use serde::{Deserialize, Serialize};
+
+/// The `[versions]` subsection of an advisory: future home to information
+/// about which versions are patched and/or unaffected.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Versions {
+    /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
+    pub patched: Vec<VersionReq>,
+
+    /// Versions which were never affected in the first place
+    #[serde(default)]
+    pub unaffected: Vec<VersionReq>,
+}

--- a/src/db/iter.rs
+++ b/src/db/iter.rs
@@ -1,8 +1,10 @@
-use super::{Advisory, AdvisoryId};
+//! `AdvisoryDatabase` iterator
+
+use crate::advisory::{self, Advisory};
 use std::collections::btree_map;
 
-/// Advisory iterator
-pub struct Iter<'a>(pub(crate) btree_map::Iter<'a, AdvisoryId, Advisory>);
+/// `AdvisoryDatabase` iterator
+pub struct Iter<'a>(pub(crate) btree_map::Iter<'a, advisory::Id, Advisory>);
 
 impl<'a> Iterator for Iter<'a> {
     type Item = &'a Advisory;

--- a/src/package.rs
+++ b/src/package.rs
@@ -8,7 +8,7 @@ use std::fmt;
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Package {
     /// Name of a crate
-    pub name: PackageName,
+    pub name: Name,
 
     /// Crate version (using `semver`)
     pub version: Version,
@@ -17,39 +17,40 @@ pub struct Package {
     pub source: Option<String>,
 
     /// Dependencies of this crate
-    pub dependencies: Option<Vec<String>>,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
 }
 
-/// Name of a crate
+/// Name of a Rust package
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct PackageName(pub String);
+pub struct Name(pub String);
 
-impl PackageName {
+impl Name {
     /// Get string reference to this package name
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
-impl AsRef<PackageName> for PackageName {
-    fn as_ref(&self) -> &PackageName {
+impl AsRef<Name> for Name {
+    fn as_ref(&self) -> &Name {
         self
     }
 }
 
-impl fmt::Display for PackageName {
+impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<'a> From<&'a str> for PackageName {
-    fn from(string: &'a str) -> PackageName {
-        PackageName(string.into())
+impl<'a> From<&'a str> for Name {
+    fn from(string: &'a str) -> Name {
+        Name(string.into())
     }
 }
 
-impl Into<String> for PackageName {
+impl Into<String> for Name {
     fn into(self) -> String {
         self.0
     }

--- a/src/repository/file.rs
+++ b/src/repository/file.rs
@@ -1,9 +1,5 @@
 use crate::error::Error;
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 /// File stored in the repository
 #[derive(Debug)]
@@ -11,7 +7,6 @@ pub(crate) struct RepoFile(PathBuf);
 
 impl RepoFile {
     /// Create a RepoFile from a relative repo `Path` and a `File`
-    #[allow(clippy::new_ret_no_self)]
     pub fn new<P: Into<PathBuf>>(path: P) -> Result<RepoFile, Error> {
         Ok(RepoFile(path.into()))
     }
@@ -19,13 +14,5 @@ impl RepoFile {
     /// Path to this file on disk
     pub fn path(&self) -> &Path {
         self.0.as_ref()
-    }
-
-    /// Read the file to a string
-    pub fn read_to_string(&self) -> Result<String, Error> {
-        let mut file = File::open(&self.0)?;
-        let mut string = String::new();
-        file.read_to_string(&mut string)?;
-        Ok(string)
     }
 }

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -2,17 +2,17 @@
 //! in a particular `Lockfile` against all advisories in an `AdvisoryDatabase`
 //! and looking for vulnerable versions.
 
-use crate::{advisory::Advisory, db::AdvisoryDatabase, lockfile::Lockfile, package::Package};
+use crate::{advisory::Advisory, db::Database, lockfile::Lockfile, package::Package};
 use serde::{Deserialize, Serialize};
 use std::{ops::Index, slice};
 
 /// A collection of vulnerabilities (i.e. matching advisories) for a given `Lockfile`
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Vulnerabilities(Vec<Vulnerability>);
+pub struct Collection(Vec<Vulnerability>);
 
-impl Vulnerabilities {
+impl Collection {
     /// Find all vulnerabilities for a given `AdvisoryDatabase` and `Lockfile`
-    pub fn find(db: &AdvisoryDatabase, lockfile: &Lockfile) -> Self {
+    pub fn find(db: &Database, lockfile: &Lockfile) -> Self {
         let mut vulns = vec![];
 
         for package in &lockfile.packages {
@@ -21,7 +21,7 @@ impl Vulnerabilities {
             }
         }
 
-        Vulnerabilities(vulns)
+        Collection(vulns)
     }
 
     /// Number of vulnerabilities
@@ -45,7 +45,7 @@ impl Vulnerabilities {
     }
 }
 
-impl Index<usize> for Vulnerabilities {
+impl Index<usize> for Collection {
     type Output = Vulnerability;
 
     fn index(&self, index: usize) -> &Vulnerability {
@@ -53,7 +53,7 @@ impl Index<usize> for Vulnerabilities {
     }
 }
 
-impl Into<Vec<Vulnerability>> for Vulnerabilities {
+impl Into<Vec<Vulnerability>> for Collection {
     fn into(self) -> Vec<Vulnerability> {
         self.0
     }
@@ -79,7 +79,7 @@ impl Vulnerability {
     }
 }
 
-impl<'a> IntoIterator for &'a Vulnerabilities {
+impl<'a> IntoIterator for &'a Collection {
     type Item = &'a Vulnerability;
     type IntoIter = Iter<'a>;
 
@@ -88,7 +88,7 @@ impl<'a> IntoIterator for &'a Vulnerabilities {
     }
 }
 
-/// Iterator over the advisory database
+/// Iterator over a collection of vulnerabilities
 pub struct Iter<'a>(slice::Iter<'a, Vulnerability>);
 
 impl<'a> Iterator for Iter<'a> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,35 +1,33 @@
 use rustsec::{
-    AdvisoryDatabase, AdvisoryId, Lockfile, PackageName, Repository, VersionReq,
-    ADVISORY_DB_REPO_URL,
+    advisory, package, Database, Lockfile, Repository, VersionReq, ADVISORY_DB_REPO_URL,
 };
-use std::str::FromStr;
 use tempfile::tempdir;
 
 /// End-to-end integration test (has online dependency on GitHub)
 #[test]
 fn happy_path() {
-    let db = AdvisoryDatabase::fetch().unwrap();
-    let example_advisory_id = AdvisoryId::from_str("RUSTSEC-2017-0001").unwrap();
+    let db = Database::fetch().unwrap();
+    let example_advisory_id = "RUSTSEC-2017-0001".parse::<advisory::Id>().unwrap();
     let example_advisory = db.find(&example_advisory_id).unwrap();
-    let example_package = PackageName::from("sodiumoxide");
+    let example_package = package::Name::from("sodiumoxide");
 
-    assert_eq!(example_advisory.id, example_advisory_id);
-    assert_eq!(example_advisory.package, example_package);
+    assert_eq!(example_advisory.info.id, example_advisory_id);
+    assert_eq!(example_advisory.info.package, example_package);
     assert_eq!(
-        example_advisory.patched_versions[0],
+        example_advisory.versions.patched[0],
         VersionReq::parse(">= 0.0.14").unwrap()
     );
-    assert_eq!(example_advisory.date.as_str(), "2017-01-26");
+    assert_eq!(example_advisory.info.date.as_str(), "2017-01-26");
     assert_eq!(
-        example_advisory.url.as_ref().unwrap(),
+        example_advisory.info.url.as_ref().unwrap(),
         "https://github.com/dnaq/sodiumoxide/issues/154"
     );
     assert_eq!(
-        example_advisory.title,
+        example_advisory.info.title,
         "scalarmult() vulnerable to degenerate public keys"
     );
     assert_eq!(
-        &example_advisory.description[0..30],
+        &example_advisory.info.description[0..30],
         "The `scalarmult()` function in"
     );
 

--- a/tests/support/example_advisory_v1.toml
+++ b/tests/support/example_advisory_v1.toml
@@ -1,0 +1,20 @@
+# Example of a V1 RustSec advisory
+# This uses the legacy `patched_versions` field, which we need to support until
+# all users have upgraded to parsers which understand the V2 format
+
+[advisory]
+id = "RUSTSEC-2001-2101"
+package = "base"
+title = "All your base are belong to us"
+description = "You have no chance to survive. Make your time."
+date = "2001-02-03"
+url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
+keywords = ["how", "are", "you", "gentlemen"]
+aliases = ["CVE-2001-2101"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+patched_versions = [">= 1.2.3"]
+
+[affected]
+arch = ["x86"]
+os = ["windows"]
+functions = { "base::belongs::All" = ["< 1.2.3"] }

--- a/tests/support/example_advisory_v2.toml
+++ b/tests/support/example_advisory_v2.toml
@@ -1,3 +1,8 @@
+# Example of a V2 RustSec advisory
+# This uses the new `[versions]` subsection, which we'd eventually like to
+# switch to, but we need to make sure all users have a `cargo-audit` which
+# supports the new format first.
+
 [advisory]
 id = "RUSTSEC-2001-2101"
 package = "base"
@@ -8,4 +13,11 @@ url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
 keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
-patched_versions = [">= 1.2.3"]
+
+[versions]
+patched = [">= 1.2.3"]
+
+[affected]
+arch = ["x86"]
+os = ["windows"]
+functions = { "base::belongs::All" = ["< 1.2.3"] }


### PR DESCRIPTION
This commit contains a pretty extensive refactor of the advisory types, which is backwards compatible with most of the existing fields (and ignores minor, old ones that have changed).

Notably, support for the (poorly utilized) `affected_*` fields is dropped, and replaced with a new restructured `[affected]` section.

Support for a `[versions]` section has also been added, which can coexist with the existing `patched_versions` and `unaffected_versions` fields. The accessors for the legacy fields are no-longer `pub`, and the new fields in the `Advisory` struct are automatically populated from the
old ones if the new ones are empty (both can be populated, but only if they match, otherwise it's considered a parse error). The migration plan would be to wait until most users have the new version of the parser (say, 6 mo - 1 yr), and then switch all of the advisories over wholesale.

Additionally this removes redundant prefixing on type names which repeat their module name, which is considered a Rust best practice:

https://github.com/rust-lang/rfcs/pull/356

The following have been renamed:

- `advisory::id::AdvisoryId` => `advisory::id::Id`
- `db::AdvisoryDatabase` => `db::Database`
- `package::PackageName` -> `package::Name`

Finally, this adds some example advisories, using the legacy `patched_versions` and `unaffected_versions` (a.k.a. "V1") and the new `[versions]` toplevel section to ensure the parser is compatible with both the old and new formats.