### PR TITLE
Add `advisory::Category` (closes RustSec/advisory-db#69)

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -1,13 +1,16 @@
 //! Security advisories in the RustSec database
 
 pub mod affected;
+pub mod category;
 pub mod date;
 pub mod id;
 pub mod info;
 pub mod keyword;
 pub mod versions;
 
-pub use self::{date::Date, id::Id, info::Info, keyword::Keyword, versions::Versions};
+pub use self::{
+    category::Category, date::Date, id::Id, info::Info, keyword::Keyword, versions::Versions,
+};
 pub use cvss::Severity;
 
 use self::affected::Affected;
@@ -69,6 +72,8 @@ impl Advisory {
                         );
                     }
                 }
+
+                $advisory.info.$old_field = vec![];
             };
         }
 

--- a/src/advisory/category.rs
+++ b/src/advisory/category.rs
@@ -1,0 +1,117 @@
+//! RustSec Vulnerability Categories
+
+use crate::error::{Error, ErrorKind};
+use serde::{de, ser, Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// RustSec Vulnerability Categories
+///
+/// The RustSec project maintains its own categorization system for
+/// vulnerabilities according to our [criteria for acceptable advisories][1].
+///
+/// This type represents the present list of allowable vulnerability types for
+/// which we allow advisories to be filed.
+///
+/// [1]: https://github.com/RustSec/advisory-db/blob/master/CONTRIBUTING.md#criteria
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum Category {
+    /// Cryptography Failure (e.g. confidentiality breakage, integrity
+    /// breakage, key leakage)
+    CryptographicFailure,
+
+    /// Attacks that cause crashes or excess resource consumption such that
+    /// software ceases to function normally, notably panics in code that is
+    /// advertised as "panic-free" (particularly in format parsers for
+    /// untrusted data)
+    DenialOfService,
+
+    /// Disclosure of local files (a.k.a. "directory traversal")
+    FileDisclosure,
+
+    /// Mishandled escaping allowing an attacker to execute code or perform
+    /// otherwise unexpected operations, e.g. shell escaping, SQL injection, XSS.
+    FormatInjection,
+
+    /// Memory unsafety vulnerabilities allowing an attacker to write to
+    /// unintended locations in memory.
+    MemoryCorruption,
+
+    /// Read-only memory safety vulnerabilities which unintentionally expose data.
+    MemoryExposure,
+
+    /// Attacks which bypass authentication and/or authorization systems,
+    /// allowing the attacker to obtain unintended privileges.
+    PrivilegeEscalation,
+
+    /// Execution of arbitrary code allowing an attacker to gain partial or
+    /// total control of an impacted computer system.
+    RemoteCodeExecution,
+}
+
+impl Category {
+    /// Get the short "kebab case" identifier for a category
+    pub fn name(self) -> &'static str {
+        match self {
+            Category::CryptographicFailure => "crypto",
+            Category::DenialOfService => "dos",
+            Category::FileDisclosure => "lfd",
+            Category::FormatInjection => "format-injection",
+            Category::MemoryCorruption => "memory-corruption",
+            Category::MemoryExposure => "memory-exposure",
+            Category::PrivilegeEscalation => "privilege-escalation",
+            Category::RemoteCodeExecution => "rce",
+        }
+    }
+
+    /// Get a brief text description of the category
+    pub fn description(self) -> &'static str {
+        match self {
+            Category::CryptographicFailure => "cryptographic failure",
+            Category::DenialOfService => "denial-of-service (DoS)",
+            Category::FileDisclosure => "file disclosure (LFD)",
+            Category::FormatInjection => "format injection",
+            Category::MemoryCorruption => "memory corruption",
+            Category::MemoryExposure => "memory exposure",
+            Category::PrivilegeEscalation => "privilege escalation",
+            Category::RemoteCodeExecution => "remote code execution (RCE)",
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl FromStr for Category {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Ok(match s {
+            "crypto" => Category::CryptographicFailure,
+            "dos" => Category::DenialOfService,
+            "lfd" => Category::FileDisclosure,
+            "format-injection" => Category::FormatInjection,
+            "memory-corruption" => Category::MemoryCorruption,
+            "memory-exposure" => Category::MemoryExposure,
+            "privilege-escalation" => Category::PrivilegeEscalation,
+            "rce" => Category::RemoteCodeExecution,
+            other => fail!(ErrorKind::Parse, "invalid category: {}", other),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Category {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let string = String::deserialize(deserializer)?;
+        string.parse().map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for Category {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}

--- a/src/advisory/info.rs
+++ b/src/advisory/info.rs
@@ -1,6 +1,6 @@
 //! Advisory information (i.e. the `[advisory]` section)
 
-use super::{date::Date, id::Id, keyword::Keyword};
+use super::{category::Category, date::Date, id::Id, keyword::Keyword};
 use crate::{package, version::VersionReq};
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,11 @@ pub struct Info {
     /// Advisory IDs which are related to this advisory
     #[serde(default)]
     pub references: Vec<Id>,
+
+    /// RustSec vulnerability categories: one of a fixed list of vulnerability
+    /// categorizations accepted by the project.
+    #[serde(default)]
+    pub categories: Vec<Category>,
 
     /// Freeform keywords which succinctly describe this vulnerability (e.g. "ssl", "rce", "xss")
     #[serde(default)]

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -1,5 +1,7 @@
 //! Tests for parsing RustSec advisories
 
+use rustsec::advisory::Category;
+
 /// Example RustSec Advisory (V1 format) to use for tests
 const ADVISORY_PATH_V1: &str = "./tests/support/example_advisory_v1.toml";
 
@@ -32,6 +34,13 @@ fn parse_metadata() {
         advisory.info.url.unwrap(),
         "https://www.youtube.com/watch?v=jQE66WA2s-A"
     );
+
+    for (i, category) in [Category::PrivilegeEscalation, Category::RemoteCodeExecution]
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(*category, advisory.info.categories[i]);
+    }
 
     for (i, kw) in ["how", "are", "you", "gentlemen"].iter().enumerate() {
         assert_eq!(*kw, advisory.info.keywords[i].as_str());
@@ -99,4 +108,10 @@ fn parse_patched_version_reqs_v2() {
     assert!(!req.matches(&"1.2.2".parse().unwrap()));
     assert!(req.matches(&"1.2.3".parse().unwrap()));
     assert!(req.matches(&"1.2.4".parse().unwrap()));
+}
+
+/// Ensure V1 and V2 formats parse equivalently
+#[test]
+fn advisory_v1_and_v2_equivalence() {
+    assert_eq!(load_advisory_v1(), load_advisory_v2());
 }

--- a/tests/support/example_advisory_v1.toml
+++ b/tests/support/example_advisory_v1.toml
@@ -9,6 +9,7 @@ title = "All your base are belong to us"
 description = "You have no chance to survive. Make your time."
 date = "2001-02-03"
 url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
+categories = ["privilege-escalation", "rce"]
 keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"

--- a/tests/support/example_advisory_v2.toml
+++ b/tests/support/example_advisory_v2.toml
@@ -10,6 +10,7 @@ title = "All your base are belong to us"
 description = "You have no chance to survive. Make your time."
 date = "2001-02-03"
 url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
+categories = ["privilege-escalation", "rce"]
 keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"


### PR DESCRIPTION
This commit adds an `[advisory.categories]` field containing a list of vulnerability categories permitted by our current criteria, similar to the `categories` feature in Cargo.toml (i.e. `keywords` are freeform, `categories` have a schema).

The category list in this PR is as follows:

- `crypto`: cryptographic failure,
- `dos`: denial-of-service,
- `lfd`: local file disclosure / directory traversal
- `format-injection`: shell escaping, SQLi, XSS, etc
- `memory-corruption`: attacker can make unintended writes to memory
- `memory-exposure`: attacker can make unintended reads from memory
- `privilege-escalation`: AuthN/AuthZ failure
- `rce`: remote code execution