### PR TITLE
Add support for "informational" advisories (closes RustSec/advisory-db#134)

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -4,12 +4,14 @@ pub mod affected;
 pub mod category;
 pub mod date;
 pub mod id;
-pub mod info;
+pub mod informational;
 pub mod keyword;
+pub mod metadata;
 pub mod versions;
 
 pub use self::{
-    category::Category, date::Date, id::Id, info::Info, keyword::Keyword, versions::Versions,
+    category::Category, date::Date, id::Id, keyword::Keyword, metadata::Metadata,
+    versions::Versions,
 };
 pub use cvss::Severity;
 
@@ -23,7 +25,7 @@ use std::{fs, path::Path, str::FromStr};
 pub struct Advisory {
     /// The `[advisory]` section of a RustSec advisory
     #[serde(rename = "advisory")]
-    pub info: Info,
+    pub metadata: Metadata,
 
     /// Versions related to this advisory which are patched or unaffected.
     ///
@@ -49,7 +51,7 @@ impl Advisory {
 
     /// Get the severity of this advisory if it has a CVSS v3 associated
     pub fn severity(&self) -> Option<Severity> {
-        self.info.cvss.as_ref().map(|cvss| cvss.severity())
+        self.metadata.cvss.as_ref().map(|cvss| cvss.severity())
     }
 
     /// Populate the new version fields from the legacy `patched_versions` and
@@ -58,22 +60,22 @@ impl Advisory {
     fn fixup_versions(&mut self) -> Result<(), Error> {
         macro_rules! populate_new_version_fields {
             ($advisory:expr, $old_field:ident, $new_field:ident) => {
-                if $advisory.versions.$new_field != $advisory.info.$old_field {
+                if $advisory.versions.$new_field != $advisory.metadata.$old_field {
                     if $advisory.versions.$new_field.is_empty() {
-                        $advisory.versions.$new_field = $advisory.info.$old_field.clone();
-                    } else if !$advisory.info.$old_field.is_empty() {
+                        $advisory.versions.$new_field = $advisory.metadata.$old_field.clone();
+                    } else if !$advisory.metadata.$old_field.is_empty() {
                         fail!(
                             ErrorKind::Parse,
                             "conflict between legacy `[advisory.{}]` \
                              and `[versions]`: '{:?}' vs '{:?}'",
                             stringify!($old_field),
-                            self.info.$old_field,
+                            self.metadata.$old_field,
                             self.versions.$new_field,
                         );
                     }
                 }
 
-                $advisory.info.$old_field = vec![];
+                $advisory.metadata.$old_field = vec![];
             };
         }
 

--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -1,0 +1,90 @@
+//! Informational advisories: ones which don't represent an immediate security
+//! threat, but something users of a crate should be warned of/aware of
+
+use crate::error::Error;
+use serde::{de, ser, Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// Categories of informational vulnerabilities
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum Informational {
+    /// Security notices for a crate which are published on <https://rustsec.org>
+    /// but don't represent a vulnerability in a crate itself.
+    Notice,
+
+    /// Crate is unmaintained / abandoned
+    Unmaintained,
+
+    /// Other types of informational advisories: left open-ended to add
+    /// more of them in the future.
+    Other(String),
+}
+
+impl Informational {
+    /// Get a `str` representing an innformationnal category
+    pub fn as_str(&self) -> &str {
+        match self {
+            Informational::Notice => "notice",
+            Informational::Unmaintained => "unmaintained",
+            Informational::Other(other) => other,
+        }
+    }
+}
+
+impl fmt::Display for Informational {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for Informational {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Ok(match s {
+            "notice" => Informational::Notice,
+            "unmaintained" => Informational::Unmaintained,
+            other => Informational::Other(other.to_owned()),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Informational {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let string = String::deserialize(deserializer)?;
+        string.parse().map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for Informational {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Informational;
+
+    #[test]
+    fn parse_notice() {
+        let notice = "notice".parse::<Informational>().unwrap();
+        assert_eq!(Informational::Notice, notice);
+        assert_eq!("notice", notice.as_str());
+    }
+
+    #[test]
+    fn parse_unmaintainend() {
+        let unmaintained = "unmaintained".parse::<Informational>().unwrap();
+        assert_eq!(Informational::Unmaintained, unmaintained);
+        assert_eq!("unmaintained", unmaintained.as_str());
+    }
+
+    #[test]
+    fn parse_other() {
+        let other = "foobar".parse::<Informational>().unwrap();
+        assert_eq!(Informational::Other("foobar".to_owned()), other);
+        assert_eq!("foobar", other.as_str());
+    }
+}

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -1,12 +1,14 @@
 //! Advisory information (i.e. the `[advisory]` section)
 
-use super::{category::Category, date::Date, id::Id, keyword::Keyword};
+use super::{
+    category::Category, date::Date, id::Id, informational::Informational, keyword::Keyword,
+};
 use crate::{package, version::VersionReq};
 use serde::{Deserialize, Serialize};
 
 /// The `[advisory]` section of a RustSec security advisory
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Info {
+pub struct Metadata {
     /// Security advisory ID (e.g. RUSTSEC-YYYY-NNNN)
     pub id: Id,
 
@@ -20,6 +22,20 @@ pub struct Info {
     #[serde(default)]
     pub aliases: Vec<Id>,
 
+    /// Advisory IDs which are related to this advisory (use `aliases` if it
+    /// is the same vulnerability syndicated to a different database)
+    #[serde(default)]
+    pub references: Vec<Id>,
+
+    /// Freeform keywords which succinctly describe this vulnerability (e.g. "ssl", "rce", "xss")
+    #[serde(default)]
+    pub keywords: Vec<Keyword>,
+
+    /// RustSec vulnerability categories: one of a fixed list of vulnerability
+    /// categorizations accepted by the project.
+    #[serde(default)]
+    pub categories: Vec<Category>,
+
     /// CVSS v3.1 Base Metrics vector string containing severity information.
     ///
     /// Example:
@@ -29,18 +45,13 @@ pub struct Info {
     /// ```
     pub cvss: Option<cvss::v3::Base>,
 
-    /// Advisory IDs which are related to this advisory
-    #[serde(default)]
-    pub references: Vec<Id>,
+    /// Informational advisories can be used to warn users about issues
+    /// affecting a particular crate without failing the build.
+    pub informational: Option<Informational>,
 
-    /// RustSec vulnerability categories: one of a fixed list of vulnerability
-    /// categorizations accepted by the project.
+    /// Is the advisory obsolete? Obsolete advisories will be ignored.
     #[serde(default)]
-    pub categories: Vec<Category>,
-
-    /// Freeform keywords which succinctly describe this vulnerability (e.g. "ssl", "rce", "xss")
-    #[serde(default)]
-    pub keywords: Vec<Keyword>,
+    pub obsolete: bool,
 
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,

--- a/src/db.rs
+++ b/src/db.rs
@@ -41,16 +41,16 @@ impl Database {
         for advisory_file in advisory_files {
             let advisory = Advisory::load_file(advisory_file.path())?;
 
-            if !advisory.info.id.is_rustsec() {
+            if !advisory.metadata.id.is_rustsec() {
                 fail!(
                     ErrorKind::Parse,
                     "expected a RUSTSEC advisory ID: {}",
-                    advisory.info.id
+                    advisory.metadata.id
                 );
             }
 
             let advisory_path = advisory_file.path().to_owned();
-            let expected_filename = OsString::from(format!("{}.toml", advisory.info.id));
+            let expected_filename = OsString::from(format!("{}.toml", advisory.metadata.id));
 
             // Ensure advisory has the correct filename
             if advisory_path.file_name().unwrap() != expected_filename {
@@ -65,29 +65,29 @@ impl Database {
             // Ensure advisory is in the correct directory
             let advisory_parent_dir = advisory_path.parent().unwrap().file_name().unwrap();
 
-            if advisory_parent_dir != OsStr::new(advisory.info.package.as_str()) {
+            if advisory_parent_dir != OsStr::new(advisory.metadata.package.as_str()) {
                 fail!(
                     ErrorKind::Repo,
                     "expected {} to be in {} directory (instead of \"{:?}\")",
-                    advisory.info.id,
-                    advisory.info.package,
+                    advisory.metadata.id,
+                    advisory.metadata.package,
                     advisory_parent_dir
                 );
             }
 
             // Ensure placeholder advisories load and parse correctly, but
             // don't actually insert them into the advisory database
-            if advisory.info.id.is_placeholder() {
+            if advisory.metadata.id.is_placeholder() {
                 continue;
             }
 
-            let crate_advisories = match crates.entry(advisory.info.package.clone()) {
+            let crate_advisories = match crates.entry(advisory.metadata.package.clone()) {
                 map::Entry::Vacant(entry) => entry.insert(vec![]),
                 map::Entry::Occupied(entry) => entry.into_mut(),
             };
 
-            crate_advisories.push(advisory.info.id.clone());
-            advisories.insert(advisory.info.id.clone(), advisory);
+            crate_advisories.push(advisory.metadata.id.clone());
+            advisories.insert(advisory.metadata.id.clone(), advisory);
         }
 
         Ok(Self { advisories, crates })

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -22,16 +22,16 @@ fn load_advisory_v2() -> rustsec::Advisory {
 #[test]
 fn parse_metadata() {
     let advisory = load_advisory_v1();
-    assert_eq!(advisory.info.id.as_str(), "RUSTSEC-2001-2101");
-    assert_eq!(advisory.info.package.as_str(), "base");
-    assert_eq!(advisory.info.title, "All your base are belong to us");
+    assert_eq!(advisory.metadata.id.as_str(), "RUSTSEC-2001-2101");
+    assert_eq!(advisory.metadata.package.as_str(), "base");
+    assert_eq!(advisory.metadata.title, "All your base are belong to us");
     assert_eq!(
-        advisory.info.description,
+        advisory.metadata.description,
         "You have no chance to survive. Make your time."
     );
-    assert_eq!(advisory.info.date.as_str(), "2001-02-03");
+    assert_eq!(advisory.metadata.date.as_str(), "2001-02-03");
     assert_eq!(
-        advisory.info.url.unwrap(),
+        advisory.metadata.url.unwrap(),
         "https://www.youtube.com/watch?v=jQE66WA2s-A"
     );
 
@@ -39,11 +39,11 @@ fn parse_metadata() {
         .iter()
         .enumerate()
     {
-        assert_eq!(*category, advisory.info.categories[i]);
+        assert_eq!(*category, advisory.metadata.categories[i]);
     }
 
     for (i, kw) in ["how", "are", "you", "gentlemen"].iter().enumerate() {
-        assert_eq!(*kw, advisory.info.keywords[i].as_str());
+        assert_eq!(*kw, advisory.metadata.keywords[i].as_str());
     }
 }
 
@@ -63,7 +63,7 @@ fn parse_affected() {
 /// Parsing of other aliased advisory IDs
 #[test]
 fn parse_aliases() {
-    let alias = &load_advisory_v1().info.aliases[0];
+    let alias = &load_advisory_v1().metadata.aliases[0];
     assert!(alias.is_cve());
     assert_eq!(alias.year().unwrap(), 2001);
 }
@@ -77,7 +77,7 @@ fn parse_cvss_vector_string() {
         rustsec::advisory::Severity::Critical
     );
 
-    let cvss = advisory.info.cvss.unwrap();
+    let cvss = advisory.metadata.cvss.unwrap();
     assert_eq!(cvss.av.unwrap(), cvss::v3::base::av::AttackVector::Network);
     assert_eq!(cvss.ac.unwrap(), cvss::v3::base::ac::AttackComplexity::Low);
     assert_eq!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,23 +11,23 @@ fn happy_path() {
     let example_advisory = db.find(&example_advisory_id).unwrap();
     let example_package = package::Name::from("sodiumoxide");
 
-    assert_eq!(example_advisory.info.id, example_advisory_id);
-    assert_eq!(example_advisory.info.package, example_package);
+    assert_eq!(example_advisory.metadata.id, example_advisory_id);
+    assert_eq!(example_advisory.metadata.package, example_package);
     assert_eq!(
         example_advisory.versions.patched[0],
         VersionReq::parse(">= 0.0.14").unwrap()
     );
-    assert_eq!(example_advisory.info.date.as_str(), "2017-01-26");
+    assert_eq!(example_advisory.metadata.date.as_str(), "2017-01-26");
     assert_eq!(
-        example_advisory.info.url.as_ref().unwrap(),
+        example_advisory.metadata.url.as_ref().unwrap(),
         "https://github.com/dnaq/sodiumoxide/issues/154"
     );
     assert_eq!(
-        example_advisory.info.title,
+        example_advisory.metadata.title,
         "scalarmult() vulnerable to degenerate public keys"
     );
     assert_eq!(
-        &example_advisory.info.description[0..30],
+        &example_advisory.metadata.description[0..30],
         "The `scalarmult()` function in"
     );
 


### PR DESCRIPTION
The intent is for `cargo-audit` to warn about these, printing their titles, but not exit with an error.

Two types of informational advisories are introduced:

- `docs`: Used when documentation/example code for a crate recommended an insecure configuration or practice. Downstream users of the crate may or may not have used such a practice in their own code, so warn users that they may have been advised to do something insecure and to check if their code needs updating.
- `unmaintained`: crate is unmaintained / abandoned.

The enum representing `Informational` advisories is kept open-ended through a third `Other(String)` variant which allows additional categories of informational advisories to be added in the future in a backwards-compatible way.

It additionally adds an `obsolete` flag which can be used to indicate an informational advisory no longer applies, which can be used when unmaintained crates find new maintainers.

Finally, it renames the previous `Info` struct (representing the `[advisory]` section) to `metadata` so as not to have `info` and `informational`, which would be confusing.