### PR TITLE
support.toml for indicating supported versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,6 @@ pub use crate::{
     advisory::*, db::*, error::*, lockfile::*, package::*, repository::*, version::*,
     vulnerability::*,
 };
+
+/// Current version of the RustSec crate
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/repository/support.rs
+++ b/src/repository/support.rs
@@ -1,0 +1,42 @@
+//! Tracking file for supported versions
+
+use crate::{advisory::date::Date, version::VersionReq};
+use serde::{Deserialize, Serialize};
+
+/// Tracking file for supported versions
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Support {
+    /// Versions of the RustSec crate
+    pub rustsec: RustSec,
+}
+
+/// Supported `rustsec` crate version metadata
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RustSec {
+    /// Supported versions of the RustSec crate
+    pub version: VersionReq,
+
+    /// Information about the next (breaking) update
+    pub next_update: Option<NextUpdate>,
+}
+
+impl RustSec {
+    /// Is the current version of this crate supported?
+    pub fn is_supported(&self) -> bool {
+        self.version.matches(&crate::VERSION.parse().unwrap())
+    }
+}
+
+/// Information about the next breaking change to the advisory DB.
+/// This allows us to both warn in advance when the file format used in
+/// the `RustSec/advisory-db` repo will have breaking changes, and also
+/// notify users with out-of-date copies of e.g. `cargo-audit` that they
+/// need to upgrade.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NextUpdate {
+    /// New minimum supported versions
+    pub version: VersionReq,
+
+    /// Date when the breaking changes are planned to be made
+    pub date: Date,
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,4 @@
-use rustsec::{
-    advisory, package, Database, Lockfile, Repository, VersionReq, ADVISORY_DB_REPO_URL,
-};
+use rustsec::{advisory, package, Database, Lockfile, Repository, VersionReq, DEFAULT_REPO_URL};
 use tempfile::tempdir;
 
 /// End-to-end integration test (has online dependency on GitHub)
@@ -46,5 +44,5 @@ fn clone_into_existing_directory() {
     let tmp = tempdir().unwrap();
 
     // Attempt to fetch into it
-    Repository::fetch(ADVISORY_DB_REPO_URL, tmp.path(), true).unwrap();
+    Repository::fetch(DEFAULT_REPO_URL, tmp.path(), true).unwrap();
 }


### PR DESCRIPTION
Until we're ready to commit to `rustsec` 1.0 (and afterward for new major versions), it would be nice to be able to incrementally make breaking changes to the advisory format, but in a way where users are properly notified that their tooling is out-of-date.

This commit implements a parser for `support.toml` in the root of the advisory database directory which contains metadata about which older versions of the `rustsec` crate's parser are currently supported.

It additionally includes a `[rustsec.next_update]` section which can be used to warn users that a breaking change is coming and they need to upgrade `cargo-audit`.