### PR TITLE
Further broaden categories

### DIFF
--- a/src/advisory/category.rs
+++ b/src/advisory/category.rs
@@ -1,6 +1,6 @@
 //! RustSec Vulnerability Categories
 
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
@@ -13,16 +13,20 @@ use std::{fmt, str::FromStr};
 /// which we allow advisories to be filed.
 ///
 /// [1]: https://github.com/RustSec/advisory-db/blob/master/CONTRIBUTING.md#criteria
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Category {
+    /// Execution of arbitrary code allowing an attacker to gain partial or
+    /// total control of an impacted computer system.
+    CodeExecution,
+
     /// Cryptography Failure (e.g. confidentiality breakage, integrity
     /// breakage, key leakage)
-    CryptographicFailure,
+    CryptoFailure,
 
-    /// Attacks that cause crashes or excess resource consumption such that
-    /// software ceases to function normally, notably panics in code that is
-    /// advertised as "panic-free" (particularly in format parsers for
-    /// untrusted data)
+    /// Vulnerabilities an attacker can leverage to cause crashes or excess
+    /// resource consumption such that software ceases to function normally,
+    /// notably panics in code that is advertised as "panic-free" (particularly
+    /// in format parsers for untrusted data)
     DenialOfService,
 
     /// Disclosure of local files (a.k.a. "directory traversal")
@@ -43,37 +47,23 @@ pub enum Category {
     /// allowing the attacker to obtain unintended privileges.
     PrivilegeEscalation,
 
-    /// Execution of arbitrary code allowing an attacker to gain partial or
-    /// total control of an impacted computer system.
-    RemoteCodeExecution,
+    /// Other types of categories: left open-ended to add more of them in the future.
+    Other(String),
 }
 
 impl Category {
     /// Get the short "kebab case" identifier for a category
-    pub fn name(self) -> &'static str {
+    pub fn name(&self) -> &str {
         match self {
-            Category::CryptographicFailure => "crypto",
-            Category::DenialOfService => "dos",
-            Category::FileDisclosure => "lfd",
+            Category::CodeExecution => "code-execution",
+            Category::CryptoFailure => "crypto-failure",
+            Category::DenialOfService => "denial-of-service",
+            Category::FileDisclosure => "file-disclosure",
             Category::FormatInjection => "format-injection",
             Category::MemoryCorruption => "memory-corruption",
             Category::MemoryExposure => "memory-exposure",
             Category::PrivilegeEscalation => "privilege-escalation",
-            Category::RemoteCodeExecution => "rce",
-        }
-    }
-
-    /// Get a brief text description of the category
-    pub fn description(self) -> &'static str {
-        match self {
-            Category::CryptographicFailure => "cryptographic failure",
-            Category::DenialOfService => "denial-of-service (DoS)",
-            Category::FileDisclosure => "file disclosure (LFD)",
-            Category::FormatInjection => "format injection",
-            Category::MemoryCorruption => "memory corruption",
-            Category::MemoryExposure => "memory exposure",
-            Category::PrivilegeEscalation => "privilege escalation",
-            Category::RemoteCodeExecution => "remote code execution (RCE)",
+            Category::Other(other) => other,
         }
     }
 }
@@ -89,15 +79,15 @@ impl FromStr for Category {
 
     fn from_str(s: &str) -> Result<Self, Error> {
         Ok(match s {
-            "crypto" => Category::CryptographicFailure,
-            "dos" => Category::DenialOfService,
-            "lfd" => Category::FileDisclosure,
+            "code-execution" => Category::CodeExecution,
+            "crypto-failure" => Category::CryptoFailure,
+            "denial-of-service" => Category::DenialOfService,
+            "file-disclosure" => Category::FileDisclosure,
             "format-injection" => Category::FormatInjection,
             "memory-corruption" => Category::MemoryCorruption,
             "memory-exposure" => Category::MemoryExposure,
             "privilege-escalation" => Category::PrivilegeEscalation,
-            "rce" => Category::RemoteCodeExecution,
-            other => fail!(ErrorKind::Parse, "invalid category: {}", other),
+            other => Category::Other(other.to_owned()),
         })
     }
 }

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -35,7 +35,7 @@ fn parse_metadata() {
         "https://www.youtube.com/watch?v=jQE66WA2s-A"
     );
 
-    for (i, category) in [Category::PrivilegeEscalation, Category::RemoteCodeExecution]
+    for (i, category) in [Category::CodeExecution, Category::PrivilegeEscalation]
         .iter()
         .enumerate()
     {

--- a/tests/support/example_advisory_v1.toml
+++ b/tests/support/example_advisory_v1.toml
@@ -9,7 +9,7 @@ title = "All your base are belong to us"
 description = "You have no chance to survive. Make your time."
 date = "2001-02-03"
 url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
-categories = ["privilege-escalation", "rce"]
+categories = ["code-execution", "privilege-escalation"]
 keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"

--- a/tests/support/example_advisory_v2.toml
+++ b/tests/support/example_advisory_v2.toml
@@ -10,7 +10,7 @@ title = "All your base are belong to us"
 description = "You have no chance to survive. Make your time."
 date = "2001-02-03"
 url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
-categories = ["privilege-escalation", "rce"]
+categories = ["code-execution", "privilege-escalation"]
 keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"


### PR DESCRIPTION
Based on the experience in https://github.com/RustSec/advisory-db/pull/146 this broadens the coarse grained categories to remove distinctions between local and remote attacks, so we don't categories local arbitrary code execution just because the overall category is "rce".

Furthermore, it removes the jargony acronyms, replacing each with the the "kebab-case" equivalent of each enum variant, which should make them more accessible to people who aren't necessarily versed in security-related acronyms.

Finally, like the `Informational` enum the `Category` enum has been changed to have an open-ended `Other` variant to support adding more categories in the future. We can lint for the currently valid ones at the time new advisories are accepted.