### PR TITLE
Basic query support

### DIFF
--- a/src/advisory/date.rs
+++ b/src/advisory/date.rs
@@ -3,7 +3,7 @@
 use crate::error::{Error, ErrorKind};
 #[cfg(feature = "chrono")]
 use chrono::{self, DateTime, Utc};
-use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Minimum allowed year on advisory dates
@@ -31,9 +31,10 @@ impl Date {
 }
 
 impl<'de> Deserialize<'de> for Date {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let string = String::deserialize(deserializer)?;
+        string.parse().map_err(D::Error::custom)
     }
 }
 

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,0 +1,122 @@
+//! Queries against the RustSec database
+
+use crate::{
+    advisory::{Advisory, Severity},
+    package,
+};
+
+/// Queries against the RustSec database
+#[derive(Clone, Debug, Default)]
+pub struct Query {
+    /// Collection to query against
+    pub(super) collection: Option<package::Collection>,
+
+    /// Package name to search for
+    pub(super) package: Option<package::Name>,
+
+    /// Severity threshold (i.e. minimum severity)
+    severity: Option<Severity>,
+
+    /// Year associated with the advisory ID
+    year: Option<u32>,
+
+    /// Query for obsolete advisories
+    obsolete: Option<bool>,
+
+    /// Query for informational advisories
+    informational: Option<bool>,
+}
+
+impl Query {
+    /// Create a new query
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set collection to query against
+    pub fn collection(mut self, collection: package::Collection) -> Self {
+        self.collection = Some(collection);
+        self
+    }
+
+    /// Set package name to search for
+    pub fn package(mut self, package: impl Into<package::Name>) -> Self {
+        self.package = Some(package.into());
+        self
+    }
+
+    /// Set minimum severity threshold according to the CVSS
+    /// Qualitative Severity Rating Scale.
+    ///
+    /// Vulnerabilities without associated CVSS information will always
+    /// match regardless of what this is set to.
+    pub fn severity(mut self, severity: Severity) -> Self {
+        self.severity = Some(severity);
+        self
+    }
+
+    /// Query for vulnerabilities occurring in a specific year.
+    pub fn year(mut self, year: u32) -> Self {
+        self.year = Some(year);
+        self
+    }
+
+    /// Query for obsolete vulnerabilities. By default they will be omitted
+    /// from query results.
+    pub fn obsolete(mut self, setting: bool) -> Self {
+        self.obsolete = Some(setting);
+        self
+    }
+
+    /// Query for informational advisories. By default they will be omitted
+    /// from query results.
+    pub fn informational(mut self, setting: bool) -> Self {
+        self.informational = Some(setting);
+        self
+    }
+
+    /// Does this query match a given advisory?
+    pub fn matches(&self, advisory: &Advisory) -> bool {
+        if let Some(collection) = self.collection {
+            if Some(collection) != advisory.metadata.collection {
+                return false;
+            }
+        }
+
+        if let Some(package) = &self.package {
+            if package != &advisory.metadata.package {
+                return false;
+            }
+        }
+
+        if let Some(query_severity) = self.severity {
+            if let Some(advisory_severity) = advisory.severity() {
+                if advisory_severity < query_severity {
+                    return false;
+                }
+            }
+        }
+
+        if let Some(query_year) = self.year {
+            if let Some(advisory_year) = advisory.metadata.id.year() {
+                if query_year != advisory_year {
+                    return false;
+                }
+            }
+        }
+
+        if let Some(obsolete) = self.obsolete {
+            if obsolete != advisory.metadata.obsolete {
+                return false;
+            }
+        }
+
+        if let Some(informational) = self.informational {
+            if informational != advisory.metadata.informational.is_some() {
+                return false;
+            }
+        }
+
+        true
+    }
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,38 @@
+//! Tests for parsing RustSec advisories
+
+use rustsec::{advisory::Severity, db::Query};
+
+/// Load the V1 advisory from the filesystem
+fn load_advisory() -> rustsec::Advisory {
+    rustsec::Advisory::load_file("./tests/support/example_advisory_v2.toml").unwrap()
+}
+
+#[test]
+fn matches_name() {
+    let advisory = load_advisory();
+
+    let query_matches = Query::new().package("base");
+    assert!(query_matches.matches(&advisory));
+
+    let query_nomatch = Query::new().package("somethingelse");
+    assert!(!query_nomatch.matches(&advisory));
+}
+
+#[test]
+fn matches_year() {
+    let advisory = load_advisory();
+
+    let query_matches = Query::new().year(2001);
+    assert!(query_matches.matches(&advisory));
+
+    let query_nomatch = Query::new().year(2525);
+    assert!(!query_nomatch.matches(&advisory));
+}
+
+#[test]
+fn matches_severity() {
+    let advisory = load_advisory();
+
+    let query_matches = Query::new().severity(Severity::Critical);
+    assert!(query_matches.matches(&advisory));
+}


### PR DESCRIPTION
Adds a `rustsec::db::Query` type capable of expressing multiple criteria used when matching relevant advisories.