### PR TITLE
package: Parse dependencies from Cargo.lock

### DIFF
--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -52,6 +52,19 @@ impl Lockfile {
 
         vulns
     }
+
+    /// Find all packages in the lockfile that depend on the given package
+    pub fn dependent_packages(&self, package: &Package) -> Vec<&Package> {
+        self.packages
+            .iter()
+            .filter(|other_package| {
+                other_package
+                    .dependencies
+                    .iter()
+                    .any(|dep| dep.name == package.name && dep.version == package.version)
+            })
+            .collect()
+    }
 }
 
 impl FromStr for Lockfile {

--- a/src/package.rs
+++ b/src/package.rs
@@ -20,8 +20,88 @@ pub struct Package {
     pub source: Option<String>,
 
     /// Dependencies of this crate
-    #[serde(default)]
-    pub dependencies: Vec<String>,
+    #[serde(
+        default,
+        serialize_with = "serialize_dependencies",
+        deserialize_with = "deserialize_dependencies"
+    )]
+    pub dependencies: Vec<Package>,
+}
+
+/// Serialize a package in `[[package.dependencies]]`
+pub(crate) fn serialize_dependencies<S>(
+    dependencies: &[Package],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: ser::Serializer,
+{
+    dependencies
+        .iter()
+        .map(|dependency| {
+            let mut dependency_string = format!("{} {}", &dependency.name, &dependency.version);
+
+            if let Some(source) = &dependency.source {
+                dependency_string = format!("{} ({})", dependency_string, source);
+            }
+
+            dependency_string
+        })
+        .collect::<Vec<_>>()
+        .serialize(serializer)
+}
+
+/// Parse a package in `[[package.dependencies]]`
+pub(crate) fn deserialize_dependencies<'de, D>(deserializer: D) -> Result<Vec<Package>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let dependencies = Vec::<String>::deserialize(deserializer)?;
+    let mut result = vec![];
+
+    for dependency_string in &dependencies {
+        let mut parts = dependency_string.split_whitespace();
+        let name_str = parts
+            .next()
+            .ok_or_else(|| de::Error::custom("empty dependency string"))?;
+
+        let version_str = parts.next().ok_or_else(|| {
+            de::Error::custom(format!(
+                "missing version for dependency: {}",
+                &dependency_string
+            ))
+        })?;
+
+        let source = parts
+            .next()
+            .map(|s| {
+                if s.len() < 2 || !s.starts_with('(') || !s.ends_with(')') {
+                    Err(de::Error::custom(format!(
+                        "malformed source in dependency: {}",
+                        &dependency_string,
+                    )))
+                } else {
+                    Ok(s[1..(s.len() - 1)].to_owned())
+                }
+            })
+            .transpose()?;
+
+        if parts.next().is_some() {
+            Err(de::Error::custom(format!(
+                "malformed dependency: {}",
+                dependency_string,
+            )))?;
+        }
+
+        result.push(Package {
+            name: name_str.into(),
+            version: version_str.parse().map_err(de::Error::custom)?,
+            source,
+            dependencies: vec![],
+        });
+    }
+
+    Ok(result)
 }
 
 /// Name of a Rust package


### PR DESCRIPTION
Parses the `dependencies` section of each package as a set of nested packages.