### PR TITLE
Add advisory::Linter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "0.3", features = ["serde"] }
-git2 = "0.8"
+git2 = "0.10"
 home = "0.5"
 platforms = { version = "0.2", features = ["serde"] }
 semver = { version = "0.9", features = ["serde"] }

--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -6,11 +6,12 @@ pub mod date;
 pub mod id;
 pub mod informational;
 pub mod keyword;
+pub mod linter;
 pub mod metadata;
 pub mod versions;
 
 pub use self::{
-    category::Category, date::Date, id::Id, keyword::Keyword, metadata::Metadata,
+    category::Category, date::Date, id::Id, keyword::Keyword, linter::Linter, metadata::Metadata,
     versions::Versions,
 };
 pub use cvss::Severity;
@@ -42,7 +43,7 @@ pub struct Advisory {
 
 impl Advisory {
     /// Load an advisory from a `RUSTSEC-20XX-NNNN.toml` file
-    pub fn load_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    pub fn load_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
         fs::read_to_string(path)
             .map_err(|e| format_err!(ErrorKind::Io, "couldn't open {}: {}", path.display(), e))?

--- a/src/advisory/affected.rs
+++ b/src/advisory/affected.rs
@@ -130,7 +130,7 @@ pub struct Identifier(String);
 
 impl Identifier {
     /// Borrow this identifier as a `str`
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -1,0 +1,289 @@
+//! Advisory linter: ensure advisories are well-formed according to the
+//! currently valid set of fields.
+//!
+//! This is run in CI at the time advisories are submitted.
+
+use super::{Advisory, Category};
+use std::{fmt, fs, path::Path};
+
+/// Lint information about a particular advisory
+#[derive(Debug)]
+pub struct Linter {
+    /// Advisory being linted
+    advisory: Advisory,
+
+    /// Errors detected during linting
+    errors: Vec<Error>,
+}
+
+impl Linter {
+    /// Lint the advisory TOML file located at the given path
+    pub fn lint_file<P: AsRef<Path>>(path: P) -> Result<Self, crate::Error> {
+        let path = path.as_ref();
+        let toml = fs::read_to_string(path).map_err(|e| {
+            format_err!(
+                crate::ErrorKind::Io,
+                "couldn't open {}: {}",
+                path.display(),
+                e
+            )
+        })?;
+
+        Self::lint_string(&toml)
+    }
+
+    /// Lint the given advisory TOML string
+    pub fn lint_string(s: &str) -> Result<Self, crate::Error> {
+        // Ensure the advisory parses according to the normal parser first
+        let advisory = s.parse::<Advisory>()?;
+
+        // Get a raw TOML value representing the document for linting
+        let toml_value = s.parse::<toml::Value>()?;
+
+        let mut linter = Self {
+            advisory,
+            errors: vec![],
+        };
+
+        linter.lint_advisory(&toml_value);
+        Ok(linter)
+    }
+
+    /// Get the parsed advisory
+    pub fn advisory(&self) -> &Advisory {
+        &self.advisory
+    }
+
+    /// Get the errors that occurred during linting
+    pub fn errors(&self) -> &[Error] {
+        self.errors.as_slice()
+    }
+
+    /// Lint the provided TOML value as the toplevel table of an advisory
+    fn lint_advisory(&mut self, advisory: &toml::Value) {
+        if let Some(table) = advisory.as_table() {
+            for (key, value) in table {
+                match key.as_str() {
+                    "advisory" => self.lint_metadata(value),
+                    "versions" => self.lint_versions(value),
+                    "affected" => self.lint_affected(value),
+                    _ => self.errors.push(Error {
+                        kind: ErrorKind::key(key),
+                        section: None,
+                        msg: None,
+                    }),
+                }
+            }
+        } else {
+            self.errors.push(Error {
+                kind: ErrorKind::Malformed,
+                section: None,
+                msg: Some("expected table"),
+            });
+        }
+    }
+
+    /// Lint the `[advisory]` metadata section
+    fn lint_metadata(&mut self, metadata: &toml::Value) {
+        if let Some(table) = metadata.as_table() {
+            for (key, value) in table {
+                match key.as_str() {
+                    "id" => {
+                        if self.advisory.metadata.id.is_other() {
+                            self.errors.push(Error {
+                                kind: ErrorKind::value("id", value.to_string()),
+                                section: Some("advisory"),
+                                msg: Some("unknown advisory ID type"),
+                            });
+                        }
+                    }
+                    "categories" => {
+                        for category in &self.advisory.metadata.categories {
+                            if let Category::Other(other) = category {
+                                self.errors.push(Error {
+                                    kind: ErrorKind::value("category", other.to_string()),
+                                    section: Some("advisory"),
+                                    msg: Some("unknown category"),
+                                });
+                            }
+                        }
+                    }
+                    "collection" => self.errors.push(Error {
+                        kind: ErrorKind::Malformed,
+                        section: Some("advisory"),
+                        msg: Some("collection shouldn't be explicit; inferred by location"),
+                    }),
+                    "url" => {
+                        if let Some(url) = value.as_str() {
+                            if !url.starts_with("https://") {
+                                self.errors.push(Error {
+                                    kind: ErrorKind::value("url", value.to_string()),
+                                    section: Some("advisory"),
+                                    msg: Some("URL must start with https://"),
+                                });
+                            }
+                        }
+                    }
+                    "patched_versions" | "unaffected_versions" => (), // TODO(tarcieri): deprecate
+                    "aliases" | "cvss" | "date" | "keywords" | "obsolete" | "package"
+                    | "references" | "title" | "description" => (),
+                    _ => self.errors.push(Error {
+                        kind: ErrorKind::key(key),
+                        section: Some("advisory"),
+                        msg: None,
+                    }),
+                }
+            }
+        } else {
+            self.errors.push(Error {
+                kind: ErrorKind::Malformed,
+                section: Some("advisory"),
+                msg: Some("expected table"),
+            });
+        }
+    }
+
+    /// Lint the `[versions]` section of an advisory
+    fn lint_versions(&mut self, versions: &toml::Value) {
+        if let Some(table) = versions.as_table() {
+            for (key, _) in table {
+                match key.as_str() {
+                    "patched" | "unaffected" => (),
+                    _ => self.errors.push(Error {
+                        kind: ErrorKind::key(key),
+                        section: Some("versions"),
+                        msg: None,
+                    }),
+                }
+            }
+        }
+    }
+
+    /// Lint the `[affected]` section of an advisory
+    fn lint_affected(&mut self, affected: &toml::Value) {
+        if let Some(table) = affected.as_table() {
+            for (key, _) in table {
+                match key.as_str() {
+                    "functions" => {
+                        for function in self.advisory.affected.as_ref().unwrap().functions.keys() {
+                            if function.segments()[0].as_str()
+                                != self.advisory.metadata.package.as_str()
+                            {
+                                self.errors.push(Error {
+                                    kind: ErrorKind::value("functions", function.to_string()),
+                                    section: Some("affected"),
+                                    msg: Some("function path must start with crate name"),
+                                });
+                            }
+                        }
+                    }
+                    "arch" | "os" => (),
+                    _ => self.errors.push(Error {
+                        kind: ErrorKind::key(key),
+                        section: Some("affected"),
+                        msg: None,
+                    }),
+                }
+            }
+        }
+    }
+}
+
+/// Lint errors
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Error {
+    /// Kind of error
+    kind: ErrorKind,
+
+    /// Section of the advisory where the error occurred
+    section: Option<&'static str>,
+
+    /// Message about why it's invalid
+    msg: Option<&'static str>,
+}
+
+impl Error {
+    /// Get the kind of error
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+
+    /// Get the section of the advisory where the error occurred
+    pub fn section(&self) -> Option<&str> {
+        self.section.as_ref().map(AsRef::as_ref)
+    }
+
+    /// Get an optional message about the lint failure
+    pub fn msg(&self) -> Option<&str> {
+        self.msg.as_ref().map(AsRef::as_ref)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.kind)?;
+
+        if let Some(section) = &self.section {
+            write!(f, " in [{}]", section)?;
+        } else {
+            write!(f, " in toplevel")?;
+        }
+
+        if let Some(msg) = &self.msg {
+            write!(f, ": {}", msg)?
+        }
+
+        Ok(())
+    }
+}
+
+/// Lint errors
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    /// Advisory is structurally malformed
+    Malformed,
+
+    /// Unknown key
+    InvalidKey {
+        /// Name of the key
+        name: String,
+    },
+
+    /// Unknown value
+    InvalidValue {
+        /// Name of the key
+        name: String,
+
+        /// Invalid value
+        value: String,
+    },
+}
+
+impl ErrorKind {
+    /// Invalid key
+    pub fn key(name: &str) -> Self {
+        ErrorKind::InvalidKey {
+            name: name.to_owned(),
+        }
+    }
+
+    /// Invalid value
+    pub fn value(name: &str, value: impl Into<String>) -> Self {
+        ErrorKind::InvalidValue {
+            name: name.to_owned(),
+            value: value.into(),
+        }
+    }
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorKind::Malformed => write!(f, "malformed content"),
+            ErrorKind::InvalidKey { name } => write!(f, "invalid key `{}`", name),
+            ErrorKind::InvalidValue { name, value } => {
+                write!(f, "invalid value `{}` for key `{}`", value, name)
+            }
+        }
+    }
+}

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -1,5 +1,7 @@
 //! Tests for parsing RustSec advisories
 
+#![warn(rust_2018_idioms, unused_qualifications)]
+
 use rustsec::advisory::Category;
 
 /// Example RustSec Advisory (V1 format) to use for tests

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,7 @@
+//! Integration test against the live `advisory-db` repo on GitHub
+
+#![warn(rust_2018_idioms, unused_qualifications)]
+
 use rustsec::{
     advisory, db::Query, package, Database, Lockfile, Repository, VersionReq, DEFAULT_REPO_URL,
 };

--- a/tests/linter.rs
+++ b/tests/linter.rs
@@ -1,0 +1,102 @@
+//! Linter tests
+
+#![warn(rust_2018_idioms, unused_qualifications)]
+
+/// Example RustSec Advisory (V1 format)
+const ADVISORY_PATH_V1: &str = "./tests/support/example_advisory_v1.toml";
+
+/// Example RustSec Advisory (V2 format)
+const ADVISORY_PATH_V2: &str = "./tests/support/example_advisory_v2.toml";
+
+/// Ensure the example advisories pass lint
+#[test]
+fn valid_examples() {
+    for path in &[ADVISORY_PATH_V1, ADVISORY_PATH_V2] {
+        let lint = rustsec::advisory::Linter::lint_file(path).unwrap();
+        assert_eq!(lint.errors(), &[]);
+    }
+}
+
+/// Example advisory used in the subsequent `#[test]`
+const INVALID_ADVISORY_TOML: &str = r#"
+    [advisory]
+    id = "LULZSEC-2001-2101"
+    package = "base"
+    collection = "crates"
+    title = "All your base are belong to us"
+    description = "You have no chance to survive. Make your time."
+    date = "2001-02-03"
+    url = "ftp://www.youtube.com/watch?v=jQE66WA2s-A"
+    categories = ["invalid-category"]
+    keywords = ["how", "are", "you", "gentlemen"]
+    aliases = ["CVE-2001-2101"]
+    cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    invalid-advisory-key = "invalid"
+
+    [versions]
+    patched = [">= 1.2.3"]
+
+    [affected]
+    arch = ["x86"]
+    os = ["windows"]
+    functions = { "notyourbase::belongs::All" = ["< 1.2.3"] }
+
+    [invalid-section]
+"#;
+
+/// Advisory which fails lint for multiple msgs
+#[test]
+fn invalid_example() {
+    let lint = rustsec::advisory::Linter::lint_string(INVALID_ADVISORY_TOML).unwrap();
+
+    // Do we get the expected number of errors?
+    assert_eq!(lint.errors().len(), 7);
+
+    // `invalid-category`
+    let invalid_category = lint.errors()[0].to_string();
+    assert_eq!(
+        invalid_category,
+        "invalid value `invalid-category` for key `category` in [advisory]: unknown category"
+    );
+
+    // explicit `collection` is disallowed
+    let explicit_collection = lint.errors()[1].to_string();
+    assert_eq!(
+        explicit_collection,
+        "malformed content in [advisory]: collection shouldn\'t be explicit; inferred by location"
+    );
+
+    // invalid advisory ID (LULZSEC)
+    let invalid_advisory_id = lint.errors()[2].to_string();
+    assert_eq!(
+        invalid_advisory_id,
+        "invalid value `\"LULZSEC-2001-2101\"` for key `id` in [advisory]: unknown advisory ID type"
+    );
+
+    // `invalid-advisory-key`
+    let invalid_advisory_key = lint.errors()[3].to_string();
+    assert_eq!(
+        invalid_advisory_key,
+        "invalid key `invalid-advisory-key` in [advisory]"
+    );
+
+    // invalid advisory URL (must start with https://)
+    let invalid_advisory_url = lint.errors()[4].to_string();
+    assert_eq!(
+        invalid_advisory_url,
+        "invalid value `\"ftp://www.youtube.com/watch?v=jQE66WA2s-A\"` \
+         for key `url` in [advisory]: URL must start with https://"
+    );
+
+    // function path that doesn't match crate name
+    let invalid_function_path = lint.errors()[5].to_string();
+    assert_eq!(
+        invalid_function_path,
+        "invalid value `notyourbase::belongs::All` for key `functions` \
+         in [affected]: function path must start with crate name"
+    );
+
+    // `invalid-section`
+    let invalid_section = lint.errors()[6].to_string();
+    assert_eq!(invalid_section, "invalid key `invalid-section` in toplevel");
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,5 +1,7 @@
 //! Tests for parsing RustSec advisories
 
+#![warn(rust_2018_idioms, unused_qualifications)]
+
 use rustsec::{advisory::Severity, db::Query};
 
 /// Load the V1 advisory from the filesystem


### PR DESCRIPTION
Lints advisories against recognized attributes, IDs, categories, and other checks.

This applies a stricter set of checks than is used by the (extensible) parser, intended to be run in CI prior to advisories being merged.