### PR TITLE
Fix unaffected versions

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -80,7 +80,7 @@ impl Advisory {
         }
 
         populate_new_version_fields!(self, patched_versions, patched);
-        populate_new_version_fields!(self, patched_versions, patched);
+        populate_new_version_fields!(self, unaffected_versions, unaffected);
 
         Ok(())
     }

--- a/tests/support/example_advisory_v1.toml
+++ b/tests/support/example_advisory_v1.toml
@@ -14,6 +14,7 @@ keywords = ["how", "are", "you", "gentlemen"]
 aliases = ["CVE-2001-2101"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
 patched_versions = [">= 1.2.3"]
+unaffected_versions = ["0.1.2"]
 
 [affected]
 arch = ["x86"]

--- a/tests/support/example_advisory_v2.toml
+++ b/tests/support/example_advisory_v2.toml
@@ -17,6 +17,7 @@ cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 1.2.3"]
+unaffected = ["0.1.2"]
 
 [affected]
 arch = ["x86"]


### PR DESCRIPTION
The macro to populate the new fields wasn't getting invoked for unaffected versions.

This commit adds them to the example advisories to ensure they're populated consistently.