### PR TITLE
cli: Initial application boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories  = ["api-bindings", "development-tools"]
 keywords    = ["audit", "rustsec", "security", "advisory", "vulnerability"]
 edition     = "2018"
 
+[workspace]
+members = ["cli"]
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name        = "rustsec-cli"
+description = "Command-line application for maintaining the RustSec Advisory Database"
+version     = "0.0.0"
+authors     = ["Tony Arcieri <bascule@gmail.com>"]
+license     = "Apache-2.0 OR MIT"
+homepage    = "https://rustsec.org"
+repository  = "https://github.com/rustsec/rustsec-crate/"
+readme      = "README.md"
+edition     = "2018"
+
+[dependencies]
+abscissa_core = "0.3.0"
+failure = "0.1"
+gumdrop = "0.6"
+lazy_static = "1"
+rustsec = { version = "0.13", path = ".." }
+serde = { version = "1", features = ["serde_derive"] }
+
+[dev-dependencies.abscissa_core]
+version = "0.3.0"
+features = ["testing"]
+

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,26 @@
+# `rustsec` CLI application
+
+The `rustsec` CLI app is an administrative utility for maintaining the
+RustSec Advisory Database.
+
+Unless you are a RustSec maintainer, you don't need to use this utility.
+Please see the [cargo-audit] utility instead.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT] or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you shall be dual licensed as above, without any
+additional terms or conditions.
+
+[cargo-audit]: https://github.com/RustSec/cargo-audit
+[LICENSE-APACHE]: https://github.com/RustSec/rustsec-crate/blob/master/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/RustSec/rustsec-crate/blob/master/LICENSE-MIT

--- a/cli/src/application.rs
+++ b/cli/src/application.rs
@@ -1,0 +1,90 @@
+//! `rustsec` CLI application
+
+use crate::{commands::RustsecCliCmd, config::AppConfig};
+use abscissa_core::{
+    application, config, logging, Application, EntryPoint, FrameworkError, StandardPaths,
+};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Application state
+    pub static ref APPLICATION: application::Lock<RustsecCliApp> = application::Lock::default();
+}
+
+/// Obtain a read-only (multi-reader) lock on the application state.
+///
+/// Panics if the application state has not been initialized.
+pub fn app_reader() -> application::lock::Reader<RustsecCliApp> {
+    APPLICATION.read()
+}
+
+/// Obtain an exclusive mutable lock on the application state.
+pub fn app_writer() -> application::lock::Writer<RustsecCliApp> {
+    APPLICATION.write()
+}
+
+/// Obtain a read-only (multi-reader) lock on the application configuration.
+///
+/// Panics if the application configuration has not been loaded.
+pub fn app_config() -> config::Reader<RustsecCliApp> {
+    config::Reader::new(&APPLICATION)
+}
+
+/// `rustsec` CLI application
+#[derive(Debug, Default)]
+pub struct RustsecCliApp {
+    /// Application configuration.
+    config: Option<AppConfig>,
+
+    /// Application state.
+    state: application::State<Self>,
+}
+
+impl Application for RustsecCliApp {
+    /// Entrypoint command for this application.
+    type Cmd = EntryPoint<RustsecCliCmd>;
+
+    /// Application configuration.
+    type Cfg = AppConfig;
+
+    /// Paths to resources within the application.
+    type Paths = StandardPaths;
+
+    /// Accessor for application configuration.
+    fn config(&self) -> &AppConfig {
+        self.config.as_ref().expect("config not loaded")
+    }
+
+    /// Borrow the application state immutably.
+    fn state(&self) -> &application::State<Self> {
+        &self.state
+    }
+
+    /// Borrow the application state mutably.
+    fn state_mut(&mut self) -> &mut application::State<Self> {
+        &mut self.state
+    }
+
+    /// Register all components used by this application.
+    fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
+        let components = self.framework_components(command)?;
+        self.state.components.register(components)
+    }
+
+    /// Post-configuration lifecycle callback.
+    fn after_config(&mut self, config: Self::Cfg) -> Result<(), FrameworkError> {
+        // Configure components
+        self.state.components.after_config(&config)?;
+        self.config = Some(config);
+        Ok(())
+    }
+
+    /// Get logging configuration from command-line options.
+    fn logging_config(&self, command: &EntryPoint<RustsecCliCmd>) -> logging::Config {
+        if command.verbose {
+            logging::Config::verbose()
+        } else {
+            logging::Config::default()
+        }
+    }
+}

--- a/cli/src/bin/rustsec/main.rs
+++ b/cli/src/bin/rustsec/main.rs
@@ -1,0 +1,11 @@
+//! Main entry point for the `rustsec` CLI application
+
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
+use rustsec_cli::application::APPLICATION;
+
+/// Boot the `rustsec` CLI application
+fn main() {
+    abscissa_core::boot(&APPLICATION);
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,0 +1,27 @@
+//! `rustsec` CLI subcommands
+
+mod version;
+
+use self::version::VersionCmd;
+use crate::config::AppConfig;
+use abscissa_core::{Command, Configurable, Help, Options, Runnable};
+use std::path::PathBuf;
+
+/// `rustsec` CLI subcommands
+#[derive(Command, Debug, Options, Runnable)]
+pub enum RustsecCliCmd {
+    /// The `help` subcommand
+    #[options(help = "get usage information")]
+    Help(Help<Self>),
+
+    /// The `version` subcommand
+    #[options(help = "display version information")]
+    Version(VersionCmd),
+}
+
+impl Configurable<AppConfig> for RustsecCliCmd {
+    /// Location of the configuration file
+    fn config_path(&self) -> Option<PathBuf> {
+        None
+    }
+}

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,0 +1,17 @@
+//! `version` subcommand
+
+#![allow(clippy::never_loop)]
+
+use super::RustsecCliCmd;
+use abscissa_core::{Command, Options, Runnable};
+
+/// `version` subcommand
+#[derive(Command, Debug, Default, Options)]
+pub struct VersionCmd {}
+
+impl Runnable for VersionCmd {
+    /// Print version message
+    fn run(&self) {
+        println!("rustsec-cli {}", RustsecCliCmd::version());
+    }
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,11 @@
+//! Configuration file
+//!
+//! This is a placeholder since this command doesn't presently have one.
+
+use abscissa_core::Config;
+use serde::{Deserialize, Serialize};
+
+/// Configuration File
+#[derive(Clone, Config, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppConfig {}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,39 @@
+//! Error types
+
+use abscissa_core::err;
+use failure::Fail;
+use std::{fmt, io};
+
+/// Error type
+#[derive(Debug)]
+pub struct Error(abscissa_core::Error<ErrorKind>);
+
+/// Kinds of errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ErrorKind {
+    /// Error in configuration file
+    #[fail(display = "config error")]
+    Config,
+
+    /// Input/output error
+    #[fail(display = "I/O error")]
+    Io,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<abscissa_core::Error<ErrorKind>> for Error {
+    fn from(other: abscissa_core::Error<ErrorKind>) -> Self {
+        Error(other)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(other: io::Error) -> Self {
+        err!(ErrorKind::Io, other).into()
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,12 @@
+//! `rustsec` CLI application
+//!
+//! Administrative tool for the RustSec Advisory Database
+
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
+pub mod application;
+pub mod commands;
+pub mod config;
+pub mod error;
+pub mod prelude;

--- a/cli/src/prelude.rs
+++ b/cli/src/prelude.rs
@@ -1,0 +1,11 @@
+//! Application-local prelude: conveniently import types/functions/macros
+//! which are generally useful and should be available everywhere.
+
+/// Application state accessors
+pub use crate::application::{app_config, app_reader, app_writer};
+
+/// Commonly used Abscissa traits
+pub use abscissa_core::{Application, Command, Runnable};
+
+/// Logging macros
+pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};

--- a/cli/tests/acceptance.rs
+++ b/cli/tests/acceptance.rs
@@ -1,0 +1,16 @@
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
+use abscissa_core::testing::prelude::*;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref RUNNER: CmdRunner = CmdRunner::default();
+}
+
+#[test]
+fn version_no_args() {
+    let mut runner = RUNNER.clone();
+    let mut cmd = runner.arg("version").capture_stdout().run();
+    cmd.stdout().expect_regex(r"\Arustsec-cli [\d\.\-]+\z");
+}


### PR DESCRIPTION
Adds initial Abscissa application boilerplate for a `rustsec` CLI tool.

The goal is to move all administrative functionality for RustSec into this tool. This includes:

- linter: Presently located in the `advisory-db` repo
- website generator: Presently located in the `rustsec.github.io` repo