### PR TITLE
cli: Add `rustsec check` subcommand

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,14 +10,16 @@ readme      = "README.md"
 edition     = "2018"
 
 [dependencies]
-abscissa_core = "0.3.0"
+abscissa_core = "0.3"
+crates_io_api = "0.5"
 failure = "0.1"
 gumdrop = "0.6"
 lazy_static = "1"
 rustsec = { version = "0.13", path = ".." }
 serde = { version = "1", features = ["serde_derive"] }
+termcolor = "1"
 
 [dev-dependencies.abscissa_core]
-version = "0.3.0"
+version = "0.3"
 features = ["testing"]
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,8 +1,9 @@
 //! `rustsec` CLI subcommands
 
+mod check;
 mod version;
 
-use self::version::VersionCmd;
+use self::{check::CheckCmd, version::VersionCmd};
 use crate::config::AppConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
@@ -10,6 +11,10 @@ use std::path::PathBuf;
 /// `rustsec` CLI subcommands
 #[derive(Command, Debug, Options, Runnable)]
 pub enum RustsecCliCmd {
+    /// The `check` subcommand
+    #[options(help = "check that the Advisory DB is well-formed")]
+    Check(CheckCmd),
+
     /// The `help` subcommand
     #[options(help = "get usage information")]
     Help(Help<Self>),

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -1,0 +1,176 @@
+//! RustSec Advisory DB Linter
+
+use crate::prelude::*;
+use abscissa_core::{Command, Runnable};
+use gumdrop::Options;
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    process::exit,
+};
+use termcolor::{
+    Color::{Green, Red},
+    ColorChoice, ColorSpec, StandardStream, WriteColor,
+};
+
+macro_rules! writeln_color {
+    ($stream:expr, $color:path, $fmt:expr, $msg:expr) => {
+        let mut color = ColorSpec::new();
+        color.bold();
+        color.set_fg(Some($color));
+        $stream.set_color(&color).unwrap();
+
+        writeln!($stream, $fmt, $msg).unwrap();
+        $stream.reset().unwrap();
+    };
+}
+
+macro_rules! writeln_success {
+    ($stream:expr, $msg:expr) => {
+        writeln_color!($stream, Green, "✔ {}", $msg);
+    };
+    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
+        writeln_success!($stream, format!($fmt, $($arg)+));
+    }
+}
+
+macro_rules! writeln_error {
+    ($stream:expr, $msg:expr) => {
+        writeln_color!($stream, Red, "✘ {}", $msg);
+    };
+    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
+        writeln_error!($stream, format!($fmt, $($arg)+));
+    }
+}
+
+/// The `rustsec check` subcommand
+#[derive(Command, Debug, Default, Options)]
+pub struct CheckCmd {
+    /// Path to the advisory database
+    #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
+    path: Vec<PathBuf>,
+}
+
+impl Runnable for CheckCmd {
+    fn run(&self) {
+        let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+        let repo = rustsec::Repository::open(self.repo_path()).unwrap_or_else(|e| {
+            status_err!(
+                "couldn't open advisory DB repo from {}: {}",
+                self.repo_path().display(),
+                e
+            );
+            exit(1);
+        });
+
+        // Ensure Advisories.toml parses
+        let db = rustsec::Database::load(&repo).unwrap();
+        let advisories = db.iter();
+
+        // Ensure we're parsing some advisories
+        if advisories.len() == 0 {
+            status_err!("no advisories found!");
+            exit(1);
+        }
+
+        writeln_success!(
+            &mut stdout,
+            "Successfully parsed {} advisories",
+            advisories.len()
+        );
+
+        let cratesio_client = crates_io_api::SyncClient::new();
+
+        let mut invalid_advisories = 0;
+
+        for advisory in advisories {
+            if !self.check_advisory(&mut stdout, &cratesio_client, advisory) {
+                invalid_advisories += 1;
+            }
+        }
+
+        if invalid_advisories == 0 {
+            writeln_success!(&mut stdout, "All advisories are well-formed");
+        } else {
+            writeln_error!(
+                &mut stdout,
+                "{} advisories contain errors!",
+                invalid_advisories
+            );
+            exit(1);
+        }
+    }
+}
+
+impl CheckCmd {
+    /// Get the path to the path to the RustSec Advisory DB get repository
+    fn repo_path(&self) -> &Path {
+        match self.path.len() {
+            0 => Path::new("."),
+            1 => self.path[0].as_path(),
+            _ => Self::print_usage_and_exit(&[]),
+        }
+    }
+
+    fn check_advisory(
+        &self,
+        stdout: &mut StandardStream,
+        cratesio_client: &crates_io_api::SyncClient,
+        advisory: &rustsec::Advisory,
+    ) -> bool {
+        if advisory.metadata.collection == Some(rustsec::Collection::Crates) {
+            match cratesio_client.get_crate(advisory.metadata.package.as_str()) {
+                Ok(response) => {
+                    if response.crate_data.name != advisory.metadata.package.as_str() {
+                        writeln_error!(
+                            stdout,
+                            "crates.io package name does not match package name in advisory for {}",
+                            advisory.metadata.package.as_str()
+                        );
+                        return false;
+                    }
+                }
+                Err(err) => {
+                    writeln_error!(
+                        stdout,
+                        "Failed to get package `{}` from crates.io: {}",
+                        advisory.metadata.package.as_str(),
+                        err
+                    );
+                    return false;
+                }
+            }
+        }
+
+        let mut advisory_path = self
+            .repo_path()
+            .join(advisory.metadata.collection.as_ref().unwrap().to_string())
+            .join(advisory.metadata.package.as_str())
+            .join(advisory.metadata.id.as_str());
+
+        advisory_path.set_extension("toml");
+
+        let lint = rustsec::advisory::Linter::lint_file(&advisory_path).unwrap();
+
+        if lint.errors().is_empty() {
+            writeln_success!(
+                stdout,
+                "{} successfully passed lint",
+                advisory_path.display()
+            );
+            true
+        } else {
+            writeln_error!(
+                stdout,
+                "{} contained the following lint errors:",
+                advisory_path.display()
+            );
+
+            for error in lint.errors() {
+                writeln!(stdout, "  - {}", error).unwrap();
+            }
+
+            false
+        }
+    }
+}

--- a/cli/src/prelude.rs
+++ b/cli/src/prelude.rs
@@ -7,5 +7,13 @@ pub use crate::application::{app_config, app_reader, app_writer};
 /// Commonly used Abscissa traits
 pub use abscissa_core::{Application, Command, Runnable};
 
+/// Error macros
+pub use abscissa_core::{ensure, fail, fatal};
+
 /// Logging macros
 pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};
+
+/// Status macros
+pub use abscissa_core::{
+    status_attr_err, status_attr_ok, status_err, status_info, status_ok, status_warn,
+};

--- a/cli/tests/acceptance.rs
+++ b/cli/tests/acceptance.rs
@@ -8,9 +8,18 @@ lazy_static! {
     pub static ref RUNNER: CmdRunner = CmdRunner::default();
 }
 
+/// Run `rustsec check` against a freshly fetched advisory DB repo
 #[test]
-fn version_no_args() {
+fn check_advisory_db() {
+    // Fetch the advisory database
+    rustsec::Repository::fetch_default_repo().unwrap();
+
     let mut runner = RUNNER.clone();
-    let mut cmd = runner.arg("version").capture_stdout().run();
-    cmd.stdout().expect_regex(r"\Arustsec-cli [\d\.\-]+\z");
+
+    runner
+        .arg("check")
+        .arg(&rustsec::Repository::default_path())
+        .capture_stdout()
+        .status()
+        .expect_success();
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -28,11 +28,9 @@ pub(crate) const ADVISORY_DB_DIRECTORY: &str = "advisory-db";
 const SUPPORT_FILE: &str = "support.toml";
 
 /// Ref for master in the local repository
-
 const LOCAL_MASTER_REF: &str = "refs/heads/master";
 
 /// Ref for master in the remote repository
-
 const REMOTE_MASTER_REF: &str = "refs/remotes/origin/master";
 
 /// Git repository for a Rust advisory DB
@@ -55,13 +53,11 @@ impl Repository {
     }
 
     /// Fetch the default repository
-
     pub fn fetch_default_repo() -> Result<Self, Error> {
         Self::fetch(DEFAULT_REPO_URL, Repository::default_path(), true)
     }
 
     /// Create a new `Repository` with the given URL and path
-
     pub fn fetch<P: Into<PathBuf>>(
         url: &str,
         into_path: P,


### PR DESCRIPTION
Imports the Advisory DB linter which is presently located inside of the `RustSec/advisory-db` git repo itself.