### PR TITLE
cli: Add `rustsec web` subcommand

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ abscissa_core = "0.3"
 crates_io_api = "0.5"
 failure = "0.1"
 gumdrop = "0.6"
+handlebars = "2"
 lazy_static = "1"
 rustsec = { version = "0.13", path = ".." }
 serde = { version = "1", features = ["serde_derive"] }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,8 +2,9 @@
 
 mod check;
 mod version;
+mod web;
 
-use self::{check::CheckCmd, version::VersionCmd};
+use self::{check::CheckCmd, version::VersionCmd, web::WebCmd};
 use crate::config::AppConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
@@ -14,6 +15,10 @@ pub enum RustsecCliCmd {
     /// The `check` subcommand
     #[options(help = "check that the Advisory DB is well-formed")]
     Check(CheckCmd),
+
+    /// The `web` subcommand
+    #[options(help = "render advisory Markdown files for the rustsec.org web site")]
+    Web(WebCmd),
 
     /// The `help` subcommand
     #[options(help = "get usage information")]

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -1,47 +1,8 @@
 //! RustSec Advisory DB Linter
 
-use crate::prelude::*;
 use abscissa_core::{Command, Runnable};
 use gumdrop::Options;
-use std::{
-    io::Write,
-    path::{Path, PathBuf},
-    process::exit,
-};
-use termcolor::{
-    Color::{Green, Red},
-    ColorChoice, ColorSpec, StandardStream, WriteColor,
-};
-
-macro_rules! writeln_color {
-    ($stream:expr, $color:path, $fmt:expr, $msg:expr) => {
-        let mut color = ColorSpec::new();
-        color.bold();
-        color.set_fg(Some($color));
-        $stream.set_color(&color).unwrap();
-
-        writeln!($stream, $fmt, $msg).unwrap();
-        $stream.reset().unwrap();
-    };
-}
-
-macro_rules! writeln_success {
-    ($stream:expr, $msg:expr) => {
-        writeln_color!($stream, Green, "✔ {}", $msg);
-    };
-    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
-        writeln_success!($stream, format!($fmt, $($arg)+));
-    }
-}
-
-macro_rules! writeln_error {
-    ($stream:expr, $msg:expr) => {
-        writeln_color!($stream, Red, "✘ {}", $msg);
-    };
-    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
-        writeln_error!($stream, format!($fmt, $($arg)+));
-    }
-}
+use std::path::{Path, PathBuf};
 
 /// The `rustsec check` subcommand
 #[derive(Command, Debug, Default, Options)]
@@ -53,124 +14,12 @@ pub struct CheckCmd {
 
 impl Runnable for CheckCmd {
     fn run(&self) {
-        let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-        let repo = rustsec::Repository::open(self.repo_path()).unwrap_or_else(|e| {
-            status_err!(
-                "couldn't open advisory DB repo from {}: {}",
-                self.repo_path().display(),
-                e
-            );
-            exit(1);
-        });
-
-        // Ensure Advisories.toml parses
-        let db = rustsec::Database::load(&repo).unwrap();
-        let advisories = db.iter();
-
-        // Ensure we're parsing some advisories
-        if advisories.len() == 0 {
-            status_err!("no advisories found!");
-            exit(1);
-        }
-
-        writeln_success!(
-            &mut stdout,
-            "Successfully parsed {} advisories",
-            advisories.len()
-        );
-
-        let cratesio_client = crates_io_api::SyncClient::new();
-
-        let mut invalid_advisories = 0;
-
-        for advisory in advisories {
-            if !self.check_advisory(&mut stdout, &cratesio_client, advisory) {
-                invalid_advisories += 1;
-            }
-        }
-
-        if invalid_advisories == 0 {
-            writeln_success!(&mut stdout, "All advisories are well-formed");
-        } else {
-            writeln_error!(
-                &mut stdout,
-                "{} advisories contain errors!",
-                invalid_advisories
-            );
-            exit(1);
-        }
-    }
-}
-
-impl CheckCmd {
-    /// Get the path to the path to the RustSec Advisory DB get repository
-    fn repo_path(&self) -> &Path {
-        match self.path.len() {
+        let repo_path = match self.path.len() {
             0 => Path::new("."),
             1 => self.path[0].as_path(),
             _ => Self::print_usage_and_exit(&[]),
-        }
-    }
+        };
 
-    fn check_advisory(
-        &self,
-        stdout: &mut StandardStream,
-        cratesio_client: &crates_io_api::SyncClient,
-        advisory: &rustsec::Advisory,
-    ) -> bool {
-        if advisory.metadata.collection == Some(rustsec::Collection::Crates) {
-            match cratesio_client.get_crate(advisory.metadata.package.as_str()) {
-                Ok(response) => {
-                    if response.crate_data.name != advisory.metadata.package.as_str() {
-                        writeln_error!(
-                            stdout,
-                            "crates.io package name does not match package name in advisory for {}",
-                            advisory.metadata.package.as_str()
-                        );
-                        return false;
-                    }
-                }
-                Err(err) => {
-                    writeln_error!(
-                        stdout,
-                        "Failed to get package `{}` from crates.io: {}",
-                        advisory.metadata.package.as_str(),
-                        err
-                    );
-                    return false;
-                }
-            }
-        }
-
-        let mut advisory_path = self
-            .repo_path()
-            .join(advisory.metadata.collection.as_ref().unwrap().to_string())
-            .join(advisory.metadata.package.as_str())
-            .join(advisory.metadata.id.as_str());
-
-        advisory_path.set_extension("toml");
-
-        let lint = rustsec::advisory::Linter::lint_file(&advisory_path).unwrap();
-
-        if lint.errors().is_empty() {
-            writeln_success!(
-                stdout,
-                "{} successfully passed lint",
-                advisory_path.display()
-            );
-            true
-        } else {
-            writeln_error!(
-                stdout,
-                "{} contained the following lint errors:",
-                advisory_path.display()
-            );
-
-            for error in lint.errors() {
-                writeln!(stdout, "  - {}", error).unwrap();
-            }
-
-            false
-        }
+        crate::linter::lint_advisories(repo_path);
     }
 }

--- a/cli/src/commands/web.rs
+++ b/cli/src/commands/web.rs
@@ -1,0 +1,16 @@
+//! Renderer for RustSec Advisory DB web site:
+//!
+//! https://rustsec.org
+
+use abscissa_core::{Command, Runnable};
+use gumdrop::Options;
+
+/// The `rustsec web` subcommand
+#[derive(Command, Debug, Default, Options)]
+pub struct WebCmd {}
+
+impl Runnable for WebCmd {
+    fn run(&self) {
+        crate::web::render_advisories();
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,4 +9,6 @@ pub mod application;
 pub mod commands;
 pub mod config;
 pub mod error;
+pub mod linter;
 pub mod prelude;
+pub mod web;

--- a/cli/src/linter.rs
+++ b/cli/src/linter.rs
@@ -1,0 +1,150 @@
+//! RustSec Advisory DB Linter
+
+use crate::prelude::*;
+use std::{io::Write, path::Path, process::exit};
+use termcolor::{
+    Color::{Green, Red},
+    ColorChoice, ColorSpec, StandardStream, WriteColor,
+};
+
+macro_rules! writeln_color {
+    ($stream:expr, $color:path, $fmt:expr, $msg:expr) => {
+        let mut color = ColorSpec::new();
+        color.bold();
+        color.set_fg(Some($color));
+        $stream.set_color(&color).unwrap();
+
+        writeln!($stream, $fmt, $msg).unwrap();
+        $stream.reset().unwrap();
+    };
+}
+
+macro_rules! writeln_success {
+    ($stream:expr, $msg:expr) => {
+        writeln_color!($stream, Green, "✔ {}", $msg);
+    };
+    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
+        writeln_success!($stream, format!($fmt, $($arg)+));
+    }
+}
+
+macro_rules! writeln_error {
+    ($stream:expr, $msg:expr) => {
+        writeln_color!($stream, Red, "✘ {}", $msg);
+    };
+    ($stream:expr, $fmt:expr, $($arg:tt)+) => {
+        writeln_error!($stream, format!($fmt, $($arg)+));
+    }
+}
+
+/// Lint all advisories in the database
+pub fn lint_advisories(repo_path: &Path) {
+    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+
+    let repo = rustsec::Repository::open(repo_path).unwrap_or_else(|e| {
+        status_err!(
+            "couldn't open advisory DB repo from {}: {}",
+            repo_path.display(),
+            e
+        );
+        exit(1);
+    });
+
+    // Ensure Advisories.toml parses
+    let db = rustsec::Database::load(&repo).unwrap();
+    let advisories = db.iter();
+
+    // Ensure we're parsing some advisories
+    if advisories.len() == 0 {
+        status_err!("no advisories found!");
+        exit(1);
+    }
+
+    writeln_success!(
+        &mut stdout,
+        "Successfully parsed {} advisories",
+        advisories.len()
+    );
+
+    let cratesio_client = crates_io_api::SyncClient::new();
+    let mut invalid_advisories = 0;
+
+    for advisory in advisories {
+        if !lint_advisory(repo_path, &mut stdout, &cratesio_client, advisory) {
+            invalid_advisories += 1;
+        }
+    }
+
+    if invalid_advisories == 0 {
+        writeln_success!(&mut stdout, "All advisories are well-formed");
+    } else {
+        writeln_error!(
+            &mut stdout,
+            "{} advisories contain errors!",
+            invalid_advisories
+        );
+        exit(1);
+    }
+}
+
+/// Lint an individual advisory in the database
+fn lint_advisory(
+    repo_path: &Path,
+    stdout: &mut StandardStream,
+    cratesio_client: &crates_io_api::SyncClient,
+    advisory: &rustsec::Advisory,
+) -> bool {
+    if advisory.metadata.collection == Some(rustsec::Collection::Crates) {
+        match cratesio_client.get_crate(advisory.metadata.package.as_str()) {
+            Ok(response) => {
+                if response.crate_data.name != advisory.metadata.package.as_str() {
+                    writeln_error!(
+                        stdout,
+                        "crates.io package name does not match package name in advisory for {}",
+                        advisory.metadata.package.as_str()
+                    );
+                    return false;
+                }
+            }
+            Err(err) => {
+                writeln_error!(
+                    stdout,
+                    "Failed to get package `{}` from crates.io: {}",
+                    advisory.metadata.package.as_str(),
+                    err
+                );
+                return false;
+            }
+        }
+    }
+
+    let mut advisory_path = repo_path
+        .join(advisory.metadata.collection.as_ref().unwrap().to_string())
+        .join(advisory.metadata.package.as_str())
+        .join(advisory.metadata.id.as_str());
+
+    advisory_path.set_extension("toml");
+
+    let lint = rustsec::advisory::Linter::lint_file(&advisory_path).unwrap();
+
+    if lint.errors().is_empty() {
+        writeln_success!(
+            stdout,
+            "{} successfully passed lint",
+            advisory_path.display()
+        );
+        true
+    } else {
+        writeln_error!(
+            stdout,
+            "{} contained the following lint errors:",
+            advisory_path.display()
+        );
+
+        for error in lint.errors() {
+            writeln!(stdout, "  - {}", error).unwrap();
+        }
+
+        false
+    }
+}

--- a/cli/src/web.rs
+++ b/cli/src/web.rs
@@ -1,0 +1,186 @@
+//! Generator for the https://rustsec.org web site
+//!
+//! Creates markdown versions of each advisory, which are rendered into a final
+//! template using markdown.
+
+use crate::prelude::*;
+use handlebars::Handlebars;
+use serde::Serialize;
+use std::{fs::File, io::Write, path::PathBuf};
+
+/// Filename of the advisory template
+pub const ADVISORY_TEMPLATE_NAME: &str = "advisory.md.hbs";
+
+/// Advisory template file (Handlebars)
+///
+/// These are rendered into Markdown, which is parsed by Jekyll and rendered
+/// into HTML. The latter step is performed by GitHub Pages itself.
+const ADVISORY_TEMPLATE_STRING: &str = r#"---
+title:       "{{id}}: {{package}}: {{title}}"
+description: "{{summary}}"
+date:        {{date}}
+tags:        {{tags}}
+permalink:   /advisories/{{id}}:output_ext
+---
+
+### Description
+
+{{{description}}}
+
+{{#if url ~}}
+### More Info
+
+<{{{url}}}>
+
+{{/if~}}
+
+### Patched Versions
+
+{{#if patched_versions~}}
+{{#each patched_versions ~}}
+- `{{{this}}}`
+{{/each~}}
+{{~else~}}
+- None!
+{{~/if}}
+
+{{#if unaffected_versions}}
+### Unaffected Versions
+
+{{#each unaffected_versions ~}}
+- `{{{this}}}`
+{{/each ~}}
+{{/if ~}}
+"#;
+
+/// Render all advisories using the Markdown template
+pub fn render_advisories() {
+    let mut handlebars = Handlebars::new();
+    handlebars.set_strict_mode(true);
+    handlebars.register_escape_fn(handlebars::no_escape);
+
+    handlebars
+        .register_template_string(ADVISORY_TEMPLATE_NAME, ADVISORY_TEMPLATE_STRING)
+        .unwrap();
+
+    let advisories: Vec<AdvisoryParams> = rustsec::Database::fetch()
+        .unwrap()
+        .iter()
+        .map(AdvisoryParams::from)
+        .collect();
+
+    for advisory in &advisories {
+        let output_path =
+            PathBuf::from("_posts").join(format!("{}-{}.md", advisory.date, advisory.id));
+
+        let mut rendered = handlebars.render(ADVISORY_TEMPLATE_NAME, advisory).unwrap();
+
+        // TODO: escaping bug? Find a better solution for (not) escaping these
+        // These are getting escaped by handlebars and are double-escaped in the HTML
+        // unless removed using the hax below
+        rendered = rendered.replace("&lt;", "<").replace("&gt;", ">");
+
+        let mut output_file = File::create(&output_path).unwrap();
+        output_file.write_all(rendered.as_bytes()).unwrap();
+
+        status_ok!("Rendered", "{}", output_path.display());
+    }
+
+    status_ok!(
+        "Completed",
+        "{} advisories rendered as Markdown",
+        advisories.len()
+    );
+}
+
+/// Parameters to pass to the `advisory.md.hbs` Handlebars template
+#[derive(Debug, Serialize)]
+pub struct AdvisoryParams {
+    /// Advisory ID (i.e. `RUSTSEC-20YY-NNNN`)
+    pub id: String,
+
+    /// Package name (i.e. crate name)
+    pub package: String,
+
+    /// Title of advisory
+    pub title: String,
+
+    /// One-liner summary of the advisory
+    pub summary: String,
+
+    /// Full description
+    pub description: String,
+
+    /// Advisory date
+    pub date: String,
+
+    /// Tags to associate with this advisory
+    pub tags: String,
+
+    /// URL for more information
+    pub url: Option<String>,
+
+    /// Patched versions
+    pub patched_versions: Vec<String>,
+
+    /// Unaffected versions
+    pub unaffected_versions: Option<Vec<String>>,
+}
+
+impl<'a> From<&'a rustsec::Advisory> for AdvisoryParams {
+    fn from(advisory: &rustsec::Advisory) -> AdvisoryParams {
+        let patched_versions = advisory
+            .versions
+            .patched
+            .iter()
+            .map(|req| req.to_string())
+            .collect();
+
+        let unaffected_versions = if advisory.versions.unaffected.is_empty() {
+            None
+        } else {
+            Some(
+                advisory
+                    .versions
+                    .unaffected
+                    .iter()
+                    .map(|req| req.to_string())
+                    .collect(),
+            )
+        };
+
+        let mut summary = advisory
+            .metadata
+            .description
+            .replace('\n', " ")
+            .replace("  ", " ");
+
+        summary.retain(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | ' ' | ',' | '.' => true,
+            _ => false,
+        });
+
+        let mut tags = vec![advisory.metadata.package.to_string()];
+
+        tags.extend(
+            advisory
+                .metadata
+                .keywords
+                .iter()
+                .map(|kw| kw.as_str().to_owned()),
+        );
+
+        Self {
+            id: advisory.metadata.id.to_string(),
+            package: advisory.metadata.package.to_string(),
+            title: advisory.metadata.title.clone(),
+            summary: summary.trim().to_owned(),
+            description: advisory.metadata.description.trim().to_owned(),
+            date: advisory.metadata.date.as_str().to_owned(),
+            tags: tags.join(" "),
+            url: advisory.metadata.url.clone(),
+            patched_versions,
+            unaffected_versions,
+        }
+    }
+}


### PR DESCRIPTION
Imports the Advisory Markdown renderer which is presently located inside of the `RustSec/rustsec.github.io` git repo itself.