### PR TITLE
v0.14.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.14.0] (2019-09-24)
+
+- warning: Extract into module; make more like `Vulnerability` ([#110])
+- Upgrade to `cvss` crate v1.0 ([#109])
+- Upgrade to `cargo-lock` crate v1.0 ([#107])
+
 ## [0.13.0] (2019-09-23)
 
 - linter: Ensure advisory date's year matches year in advisory ID ([#99])
@@ -130,6 +136,10 @@
 
 - Initial release
 
+[0.14.0]: https://github.com/RustSec/rustsec-crate/pull/111
+[#110]: https://github.com/RustSec/rustsec-crate/pull/110
+[#109]: https://github.com/RustSec/rustsec-crate/pull/109
+[#107]: https://github.com/RustSec/rustsec-crate/pull/107
 [0.13.0]: https://github.com/RustSec/rustsec-crate/pull/103
 [#99]: https://github.com/RustSec/rustsec-crate/pull/99
 [#97]: https://github.com/RustSec/rustsec-crate/pull/97

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ failure = "0.1"
 gumdrop = "0.6"
 handlebars = "2"
 lazy_static = "1"
-rustsec = { version = "0.13", path = ".." }
+rustsec = { version = "0.14", path = ".." }
 serde = { version = "1", features = ["serde_derive"] }
 termcolor = "1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.13.0"
+    html_root_url = "https://docs.rs/rustsec/0.14.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- warning: Extract into module; make more like `Vulnerability` (#110)
- Upgrade to `cvss` crate v1.0 (#109)
- Upgrade to `cargo-lock` crate v1.0 (#107)