### PR TITLE
Upgrade to cargo-lock v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition     = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cargo-lock = "1"
+cargo-lock = "2"
 chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "1", features = ["serde"] }
 git2 = "0.10"


### PR DESCRIPTION
The previous version had some showstopper bugs which required API changes.

Full changelog here:

https://github.com/RustSec/cargo-lock/pull/21