### PR TITLE
Upgrade to `cargo-lock` crate v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition     = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cargo-lock = "2"
+cargo-lock = "3"
 chrono = { version = "0.4", features = ["serde"] }
 cvss = { version = "1", features = ["serde"] }
 git2 = "0.10"


### PR DESCRIPTION
Since these types are re-exported publically via this crate's API (and are an essential part of it), this is a semver breaking change.