### PR TITLE
repository: Expose `authentication` module

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,8 +1,8 @@
 //! Git repository handling for the RustSec advisory DB
 
-mod authentication;
-mod commit;
-mod signature;
+pub mod authentication;
+pub mod commit;
+pub mod signature;
 pub mod support;
 
 pub use self::{commit::Commit, signature::Signature};

--- a/src/repository/authentication.rs
+++ b/src/repository/authentication.rs
@@ -33,7 +33,7 @@ use std::env;
 /// credentials until we give it a reason to not do so. To ensure we don't
 /// just sit here looping forever we keep track of authentications we've
 /// attempted and we don't try the same ones again.
-pub(crate) fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F) -> Result<T, Error>
+pub fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F) -> Result<T, Error>
 where
     F: FnMut(&mut git2::Credentials<'_>) -> Result<T, Error>,
 {
@@ -217,5 +217,6 @@ where
         }
         format_err!(ErrorKind::Repo, "{}", msg)
     })?;
+
     Ok(res)
 }

--- a/src/repository/signature.rs
+++ b/src/repository/signature.rs
@@ -1,3 +1,5 @@
+//! Git commit signatures
+
 use crate::error::Error;
 
 /// Digital signatures (in OpenPGP format) on commits to the repository

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -75,7 +75,7 @@ fn verify_cve_2018_1000810(db: &Database) {
     );
     assert_eq!(
         example_advisory.metadata.title,
-        "Buffer overflow vulnenrability in str::repeat()"
+        "Buffer overflow vulnerability in str::repeat()"
     );
     assert_eq!(
         &example_advisory.metadata.description[0..30],


### PR DESCRIPTION
This is useful in the context of the `rustsec-admin` tool in order to construct the git authentication callbacks necessary to fetch the repository, which is needed to pull commits from remote PRs.