### PR TITLE
v0.15.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.15.1] (2019-10-07)
+
+- linter: Add `informational` as an allowable `[advisory]` key ([#118])
+- repository: Expose `authentication` module ([#117])
+
 ## [0.15.0] (2019-10-01)
 
 - Upgrade to `cargo-lock` crate v3.0 ([#115])
@@ -144,6 +149,9 @@
 
 - Initial release
 
+[0.15.1]: https://github.com/RustSec/rustsec-crate/pull/121
+[#118]: https://github.com/RustSec/rustsec-crate/pull/118
+[#117]: https://github.com/RustSec/rustsec-crate/pull/117
 [0.15.0]: https://github.com/RustSec/rustsec-crate/pull/116
 [#115]: https://github.com/RustSec/rustsec-crate/pull/115
 [0.14.1]: https://github.com/RustSec/rustsec-crate/pull/114

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.15.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.15.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.15.0"
+    html_root_url = "https://docs.rs/rustsec/0.15.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- linter: Add `informational` as an allowable `[advisory]` key (#118)
- repository: Expose `authentication` module (#117)