### PR TITLE
version: Fix matching bug for `>` version requirements

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -123,6 +123,7 @@ mod tests {
         assert!(version_req("= 0.0.0").matches(&version("0.0.0")));
         assert!(version_req("> 0.0.0").matches(&version("0.0.1")));
         assert!(version_req("< 1.0.0").matches(&version("0.0.1")));
+        assert!(!version_req("> 1.0.0").matches(&version("1.0.0")));
     }
 
     // Test case from: <https://github.com/RustSec/cargo-audit/issues/30>

--- a/src/version/predicate.rs
+++ b/src/version/predicate.rs
@@ -88,7 +88,11 @@ impl Predicate {
             None => return false,
         }
 
-        !(self.pre.is_empty() && ver.is_prerelease())
+        if self.pre.is_empty() {
+            false
+        } else {
+            !ver.is_prerelease()
+        }
     }
 
     // see https://www.npmjs.org/doc/misc/semver.html for behavior


### PR DESCRIPTION
The changes to the vendored `semver` code which alter the prerelease handling behavior contained a bug/edge case where the `Predicate::is_greater` method would match in the event the provided version is equal to the requirement.

This commit adds a test for this case and includes corrected logic which handles this case correctly.