### PR TITLE
Try to auto-detect proxy setting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         toolchain:
-          - 1.35.0
+          - 1.36.0
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ database in other capacities.
 
 ## Requirements
 
-- Rust **1.35+**
+- Rust **1.36+**
 
 ## License
 
@@ -51,7 +51,7 @@ additional terms or conditions.
 [build-link]: https://github.com/rustsec/rustsec-crate/actions
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [gitter-image]: https://badges.gitter.im/badge.svg
 [gitter-link]: https://gitter.im/RustSec/Lobby

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -91,8 +91,12 @@ impl Repository {
             let mut callbacks = git2::RemoteCallbacks::new();
             callbacks.credentials(f);
 
+            let mut proxy_opts = git2::ProxyOptions::new();
+            proxy_opts.auto();
+
             let mut fetch_opts = git2::FetchOptions::new();
             fetch_opts.remote_callbacks(callbacks);
+            fetch_opts.proxy_options(proxy_opts);
 
             if path.exists() {
                 let repo = git2::Repository::open(&path)?;


### PR DESCRIPTION
Set `proxy_options` to `auto` when fetching the repository, which tells libgit2 to try to auto-detect proxy from the environment and git settings.

I've successfully tested this at work (where using a HTTPS proxy is required) with the environment variable `https_proxy` set appropriately. Looking at the libgit2 source it seems to check for `http_proxy`, `https_proxy`, `HTTP_PROXY` and `HTTPS_PROXY` env variables.

I've also tested this at home without any proxy and the `https_proxy` etc env variables unset.

Closes #94.