### PR TITLE
Add vendored-openssl feature (fixes RustSec/cargo-audit#163)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = "3"
 
 [features]
 dependency-tree = ["cargo-lock/dependency-tree"]
+vendored-openssl = ["git2/vendored-openssl"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This exposes git2's `vendored-openssl` feature, the primary reason is to make compiling for musl vastly easier.