### PR TITLE
Warn for yanked crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 cargo-lock = "3"
 chrono = { version = "0.4", features = ["serde"] }
+crates-index = "0.13"
 cvss = { version = "1", features = ["serde"] }
 git2 = "0.11"
 home = "0.5"
@@ -24,6 +25,7 @@ platforms = { version = "0.2", features = ["serde"] }
 semver = { version = "0.9", features = ["serde"] }
 semver-parser = "0.9"
 serde = { version = "1", features = ["serde_derive"] }
+thiserror = "1"
 toml = "0.5"
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use std::{
     io,
     str::Utf8Error,
 };
+use thiserror::Error;
 use toml;
 
 /// Create a new error (of a given enum variant) with a formatted message
@@ -66,36 +67,35 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 /// Custom error type for this library
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 pub enum ErrorKind {
     /// Invalid argument or parameter
+    #[error("bad parameter")]
     BadParam,
 
     /// An error occurred performing an I/O operation (e.g. network, file)
+    #[error("I/O operation failed")]
     Io,
 
+    /// Not found
+    #[error("not found")]
+    NotFound,
+
     /// Couldn't parse response data
+    #[error("parse error")]
     Parse,
 
+    /// Registry-related error
+    #[error("registry")]
+    Registry,
+
     /// Git operation failed
+    #[error("git operation failed")]
     Repo,
 
     /// Errors related to versions
+    #[error("bad version")]
     Version,
-}
-
-impl Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let description = match self {
-            ErrorKind::BadParam => "bad parameter",
-            ErrorKind::Io => "I/O operation failed",
-            ErrorKind::Parse => "parse error",
-            ErrorKind::Repo => "git operation failed",
-            ErrorKind::Version => "bad version",
-        };
-
-        write!(f, "{}", description)
-    }
 }
 
 impl From<Utf8Error> for Error {
@@ -125,6 +125,12 @@ impl From<git2::Error> for Error {
 impl From<io::Error> for Error {
     fn from(other: io::Error) -> Self {
         format_err!(ErrorKind::Io, &other)
+    }
+}
+
+impl From<crates_index::Error> for Error {
+    fn from(other: crates_index::Error) -> Self {
+        format_err!(ErrorKind::Registry, "{}", other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod advisory;
 pub mod collection;
 pub mod database;
+pub mod registry;
 pub mod report;
 pub mod repository;
 pub mod version;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,77 @@
+//! Support for interacting with the local crates.io registry index
+
+use crate::{
+    error::{Error, ErrorKind},
+    package,
+};
+
+/// Crates.io registry index (local copy)
+pub struct Index(crates_index::Index);
+
+impl Index {
+    /// Open the local copy of the crates.io registry index
+    pub fn open() -> Result<Self, Error> {
+        let index = crates_index::Index::new_cargo_default();
+
+        if index.exists() {
+            index.update()?;
+        } else {
+            index.retrieve()?;
+        }
+
+        Ok(Index(index))
+    }
+
+    /// Find an entry for a particular package in the index
+    pub fn find(
+        &self,
+        package: &package::Name,
+        version: &package::Version,
+    ) -> Result<IndexPackage, Error> {
+        let crate_releases = self.0.crate_(package.as_str()).ok_or_else(|| {
+            format_err!(
+                ErrorKind::NotFound,
+                "no results for: {} {}",
+                &package,
+                &version
+            )
+        })?;
+
+        let crate_release = crate_releases
+            .versions()
+            .iter()
+            .find(|crate_version| crate_version.version() == version.to_string())
+            .ok_or_else(|| {
+                format_err!(
+                    ErrorKind::NotFound,
+                    "no results for: {} {}",
+                    &package,
+                    &version
+                )
+            })?;
+
+        Ok(IndexPackage::from(crate_release))
+    }
+}
+
+/// Release of the package in the crates.io registry
+pub struct IndexPackage {
+    /// Name of this package
+    pub package: package::Name,
+
+    /// Version of this package
+    pub version: package::Version,
+
+    /// Is this package yanked?
+    pub is_yanked: bool,
+}
+
+impl From<&crates_index::Version> for IndexPackage {
+    fn from(crate_release: &crates_index::Version) -> IndexPackage {
+        IndexPackage {
+            package: crate_release.name().parse().unwrap(),
+            version: crate_release.version().parse().unwrap(),
+            is_yanked: crate_release.is_yanked(),
+        }
+    }
+}

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -6,27 +6,48 @@ use serde::{Deserialize, Serialize};
 /// Warnings sourced from the Advisory DB
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Warning {
-    /// Security advisory warning was sourced from
-    pub advisory: advisory::Metadata,
-
-    /// Versions impacted by this warning
-    pub versions: advisory::Versions,
+    /// Kind of warning
+    pub kind: Kind,
 
     /// Name of the dependent package
     pub package: Package,
 }
 
 impl Warning {
-    /// Create `Warning` about a given [`Advisory`] and [`Package`]
-    pub(crate) fn new(
-        advisory: &advisory::Metadata,
-        versions: &advisory::Versions,
-        package: &Package,
-    ) -> Self {
+    /// Create `Warning` of the given kind
+    pub(crate) fn new(kind: Kind, package: &Package) -> Self {
         Self {
-            advisory: advisory.clone(),
-            versions: versions.clone(),
+            kind,
             package: package.clone(),
         }
     }
+}
+
+/// Kinds of warnings
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum Kind {
+    /// Unmaintained packages
+    #[serde(rename = "unmaintained")]
+    Unmaintained {
+        /// Source advisory
+        advisory: advisory::Metadata,
+
+        /// Versions impacted by this warning
+        versions: advisory::Versions,
+    },
+
+    /// Informational advisories
+    #[serde(rename = "informational")]
+    Informational {
+        /// Source advisory
+        advisory: advisory::Metadata,
+
+        /// Versions impacted by this warning
+        versions: advisory::Versions,
+    },
+
+    /// Yanked packages
+    #[serde(rename = "yanked")]
+    Yanked,
 }


### PR DESCRIPTION
Uses the `crates-index` crate to consume yanked crate information from the local copy of the crates.io registry index.