### PR TITLE
v0.17.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.17.0] (2020-01-19)
+
+- Bump MSRV to 1.39 ([#140])
+- Extract `cargo audit fix` logic into `Fixer` ([#136])
+- Warn for yanked crates ([#135])
+- Add `vendored-openssl` feature ([#130])
+- Support crate sources as a vulnerability query attribute ([#128])
+- Try to auto-detect proxy setting ([#126])
+
 ## [0.16.0] (2019-10-13)
 
 - Remove `support.toml` parsing ([#124])
@@ -157,6 +166,13 @@
 
 - Initial release
 
+[0.17.0]: https://github.com/RustSec/rustsec-crate/pull/141
+[#140]: https://github.com/RustSec/rustsec-crate/pull/140
+[#136]: https://github.com/RustSec/rustsec-crate/pull/136
+[#135]: https://github.com/RustSec/rustsec-crate/pull/135
+[#130]: https://github.com/RustSec/rustsec-crate/pull/130
+[#128]: https://github.com/RustSec/rustsec-crate/pull/128
+[#126]: https://github.com/RustSec/rustsec-crate/pull/126
 [0.16.0]: https://github.com/RustSec/rustsec-crate/pull/125
 [#124]: https://github.com/RustSec/rustsec-crate/pull/124
 [0.15.2]: https://github.com/RustSec/rustsec-crate/pull/123

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustsec"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cargo-edit 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-lock 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.16.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.17.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.16.0"
+    html_root_url = "https://docs.rs/rustsec/0.17.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Bump MSRV to 1.39 (#140)
- Extract `cargo audit fix` logic into `Fixer` (#136)
- Warn for yanked crates (#135)
- Add `vendored-openssl` feature (#130)
- Support crate sources as a vulnerability query attribute (#128)
- Try to auto-detect proxy setting (#126)