### PR TITLE
v0.17.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.17.1] (2020-01-22)
+
+- Update `cargo-lock` requirement from 3.0 to 4.0 ([#143])
+
 ## [0.17.0] (2020-01-19)
 
 - Bump MSRV to 1.39 ([#140])
@@ -166,6 +170,8 @@
 
 - Initial release
 
+[0.17.1]: https://github.com/RustSec/rustsec-crate/pull/144
+[#143]: https://github.com/RustSec/rustsec-crate/pull/143
 [0.17.0]: https://github.com/RustSec/rustsec-crate/pull/141
 [#140]: https://github.com/RustSec/rustsec-crate/pull/140
 [#136]: https://github.com/RustSec/rustsec-crate/pull/136

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustsec"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.17.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.17.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.17.0"
+    html_root_url = "https://docs.rs/rustsec/0.17.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Update `cargo-lock` requirement from 3.0 to 4.0 (#143)