### PR TITLE
Move yanked crate auditing to `cargo-audit`

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -9,14 +9,29 @@ use crate::{
 pub struct Index(crates_index::Index);
 
 impl Index {
-    /// Open the local copy of the crates.io registry index
-    pub fn open() -> Result<Self, Error> {
+    /// Open the local crates.io index, fetching it if it doesn't exist, and
+    /// updating it if it does.
+    pub fn fetch() -> Result<Self, Error> {
         let index = crates_index::Index::new_cargo_default();
 
         if index.exists() {
             index.update()?;
         } else {
             index.retrieve()?;
+        }
+
+        Ok(Index(index))
+    }
+
+    /// Open the local crates.io index, erroring if it hasn't been fetched yet
+    pub fn open() -> Result<Self, Error> {
+        let index = crates_index::Index::new_cargo_default();
+
+        if !index.exists() {
+            fail!(
+                ErrorKind::Registry,
+                "crates.io registry has not been fetched yet"
+            );
         }
 
         Ok(Index(index))

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -15,7 +15,7 @@ pub struct Warning {
 
 impl Warning {
     /// Create `Warning` of the given kind
-    pub(crate) fn new(kind: Kind, package: &Package) -> Self {
+    pub fn new(kind: Kind, package: &Package) -> Self {
         Self {
             kind,
             package: package.clone(),


### PR DESCRIPTION
Having yanked crate auditing in the `rustsec` crate makes it hard to customize and display progress.

This commit makes the necessary changes to move the actual yanked crate auditing to `cargo-audit` itself:

- removes the `find_yanked_crates()` function, moving the functionality into `cargo-audit` itself
- adds `pub` to `Warning::new` so `cargo-audit` can construct warnings
- splits `registry::Index::open()` into separate `fetch()` and `open()` methods ala `Database` which attempt to fetch/update the crates.io or just open the local copy respectively