### PR TITLE
[WIP] V3 Advisory Format

### DIFF
--- a/tests/support/example_advisory_v3.md
+++ b/tests/support/example_advisory_v3.md
@@ -1,0 +1,23 @@
+---toml
+[advisory]
+id = "RUSTSEC-2001-2101"
+package = "base"
+title = "All your base are belong to us"
+date = "2001-02-03"
+url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
+categories = ["code-execution", "privilege-escalation"]
+keywords = ["how", "are", "you", "gentlemen"]
+aliases = ["CVE-2001-2101"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = [">= 1.2.3"]
+unaffected = ["0.1.2"]
+
+[affected]
+arch = ["x86"]
+os = ["windows"]
+functions = { "base::belongs::All" = ["< 1.2.3"] }
+---
+
+You have no chance to survive. Make your time.


### PR DESCRIPTION
This is a proposed new advisory format based on Markdown with embedded TOML front matter.

Uses triple backquotes + `toml` for the front matter delimiter, which renders correctly as syntax highlighted TOML on GitHub. This is a bit unusual way to specify front matter (typically it's YAML with `---` delimiters) but it seems to work ok.

The advisory `title` and `description` are moved out-of-band from the rest of the advisory into the underlying Markdown document. This allows it to render correctly on e.g. GitHub.