### PR TITLE
V3 Advisory Format

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -38,10 +38,86 @@ impl Advisory {
     /// Load an advisory from a `RUSTSEC-20XX-NNNN.toml` file
     pub fn load_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
-        dbg!(&path);
-        fs::read_to_string(path)
-            .map_err(|e| format_err!(ErrorKind::Io, "couldn't open {}: {}", path.display(), e))?
-            .parse()
+
+        // TODO(tarcieri): deprecate and remove legacy TOML-based advisory format
+        match path.extension().and_then(|ext| ext.to_str()) {
+            Some("toml") => {
+                // Legacy TOML-based advisory format
+                fs::read_to_string(path)
+                    .map_err(|e| {
+                        format_err!(ErrorKind::Io, "couldn't open {}: {}", path.display(), e)
+                    })?
+                    .parse()
+            }
+            Some("md") => {
+                // New V3 Markdown-based advisory format
+                Self::parse_v3(path)
+            }
+            _ => fail!(
+                ErrorKind::Repo,
+                "unexpected file extension: {}",
+                path.display()
+            ),
+        }
+    }
+
+    /// Parse a V3 advisory from a string
+    pub fn parse_v3(path: &Path) -> Result<Self, Error> {
+        let advisory_data = fs::read_to_string(path)
+            .map_err(|e| format_err!(ErrorKind::Io, "couldn't open {}: {}", path.display(), e))?;
+
+        if !advisory_data.starts_with("```toml") {
+            fail!(
+                ErrorKind::Parse,
+                "unexpected start of V3 advisory: {}",
+                path.display()
+            )
+        }
+
+        let toml_end = advisory_data.find("\n```").ok_or_else(|| {
+            format_err!(
+                ErrorKind::Parse,
+                "couldn't find end of TOML front matter in advisory: {}",
+                path.display()
+            )
+        })?;
+
+        let front_matter = advisory_data[7..toml_end].trim_start().trim_end();
+        let mut advisory: Self = toml::from_str(front_matter)?;
+
+        if advisory.metadata.title != "" || advisory.metadata.description != "" {
+            fail!(
+                ErrorKind::Parse,
+                "Markdown advisories MUST have empty title/description: {}",
+                path.display()
+            )
+        }
+
+        let markdown = advisory_data[(toml_end + 4)..].trim_start();
+
+        if !markdown.starts_with("# ") {
+            fail!(
+                ErrorKind::Parse,
+                "Expected # header after TOML front matter in: {}",
+                path.display()
+            );
+        }
+
+        let next_newline = markdown.find('\n').ok_or_else(|| {
+            format_err!(
+                ErrorKind::Parse,
+                "no Markdown body (i.e. description) found: {}",
+                path.display()
+            )
+        })?;
+
+        advisory.metadata.title = markdown[2..next_newline].trim_end().to_owned();
+        advisory.metadata.description = markdown[(next_newline + 1)..]
+            .trim_start()
+            .trim_end()
+            .to_owned();
+
+        Ok(advisory)
     }
 
     /// Get the severity of this advisory if it has a CVSS v3 associated
@@ -54,6 +130,16 @@ impl FromStr for Advisory {
     type Err = Error;
 
     fn from_str(toml_string: &str) -> Result<Self, Error> {
-        Ok(toml::from_str(toml_string)?)
+        let advisory: Self = toml::from_str(toml_string)?;
+
+        if advisory.metadata.title == "" || advisory.metadata.description == "" {
+            fail!(
+                ErrorKind::Parse,
+                "missing title and/or description in advisory:\n\n{}",
+                toml_string
+            )
+        }
+
+        Ok(advisory)
     }
 }

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -15,6 +15,14 @@ pub struct Metadata {
     /// Name of affected crate
     pub package: package::Name,
 
+    /// One-liner description of a vulnerability
+    #[serde(default)]
+    pub title: String,
+
+    /// Extended description of a vulnerability
+    #[serde(default)]
+    pub description: String,
+
     /// Date this advisory was officially issued
     pub date: Date,
 
@@ -60,12 +68,6 @@ pub struct Metadata {
 
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,
-
-    /// One-liner description of a vulnerability
-    pub title: String,
-
-    /// Extended description of a vulnerability
-    pub description: String,
 
     /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
     // TODO(tarcieri): phase this out

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -5,17 +5,33 @@
 use rustsec::advisory::Category;
 
 /// Example RustSec Advisory (V2 format) to use for tests
-const ADVISORY_PATH: &str = "./tests/support/example_advisory_v2.toml";
+const ADVISORY_V2_PATH: &str = "./tests/support/example_advisory_v2.toml";
 
-/// Load the V1 advisory from the filesystem
-fn load_advisory() -> rustsec::Advisory {
-    rustsec::Advisory::load_file(ADVISORY_PATH).unwrap()
+/// Example RustSec Advisory (V2 format) to use for tests
+const ADVISORY_V3_PATH: &str = "./tests/support/example_advisory_v3.md";
+
+/// Load V2 advisory from the filesystem
+fn load_advisory_v2() -> rustsec::Advisory {
+    rustsec::Advisory::load_file(ADVISORY_V2_PATH).unwrap()
+}
+
+/// Load V3 advisory from the filesystem
+#[test]
+fn load_advisory_v3() {
+    let advisory = rustsec::Advisory::parse_v3(std::path::Path::new(ADVISORY_V3_PATH)).unwrap();
+    assert_eq!(advisory.metadata.id.as_str(), "RUSTSEC-2001-2101");
+    assert_eq!(advisory.metadata.package.as_str(), "base");
+    assert_eq!(advisory.metadata.title, "All your base are belong to us");
+    assert_eq!(
+        advisory.metadata.description,
+        "You have no chance to survive. Make your time."
+    );
 }
 
 /// Basic metadata
 #[test]
 fn parse_metadata() {
-    let advisory = load_advisory();
+    let advisory = load_advisory_v2();
     assert_eq!(advisory.metadata.id.as_str(), "RUSTSEC-2001-2101");
     assert_eq!(advisory.metadata.package.as_str(), "base");
     assert_eq!(advisory.metadata.title, "All your base are belong to us");
@@ -44,7 +60,7 @@ fn parse_metadata() {
 /// Parsing of impact metadata
 #[test]
 fn parse_affected() {
-    let affected = load_advisory().affected.unwrap();
+    let affected = load_advisory_v2().affected.unwrap();
     assert_eq!(affected.arch[0], platforms::target::Arch::X86);
     assert_eq!(affected.os[0], platforms::target::OS::Windows);
 
@@ -57,7 +73,7 @@ fn parse_affected() {
 /// Parsing of other aliased advisory IDs
 #[test]
 fn parse_aliases() {
-    let alias = &load_advisory().metadata.aliases[0];
+    let alias = &load_advisory_v2().metadata.aliases[0];
     assert!(alias.is_cve());
     assert_eq!(alias.year().unwrap(), 2001);
 }
@@ -65,7 +81,7 @@ fn parse_aliases() {
 /// Parsing of CVSS v3.1 severity vector strings
 #[test]
 fn parse_cvss_vector_string() {
-    let advisory = load_advisory();
+    let advisory = load_advisory_v2();
     assert_eq!(
         advisory.severity().unwrap(),
         rustsec::advisory::Severity::Critical
@@ -89,7 +105,7 @@ fn parse_cvss_vector_string() {
 /// Parsing of patched version reqs (V2 format)
 #[test]
 fn parse_patched_version_reqs_v2() {
-    let req = &load_advisory().versions.patched[0];
+    let req = &load_advisory_v2().versions.patched[0];
     assert!(!req.matches(&"1.2.2".parse().unwrap()));
     assert!(req.matches(&"1.2.3".parse().unwrap()));
     assert!(req.matches(&"1.2.4".parse().unwrap()));

--- a/tests/support/example_advisory_v3.md
+++ b/tests/support/example_advisory_v3.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-2001-2101"
+package = "base"
+date = "2001-02-03"
+url = "https://www.youtube.com/watch?v=jQE66WA2s-A"
+categories = ["code-execution", "privilege-escalation"]
+keywords = ["how", "are", "you", "gentlemen"]
+aliases = ["CVE-2001-2101"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = [">= 1.2.3"]
+unaffected = ["0.1.2"]
+
+[affected]
+arch = ["x86"]
+os = ["windows"]
+functions = { "base::belongs::All" = ["< 1.2.3"] }
+```
+
+# All your base are belong to us
+
+You have no chance to survive. Make your time.


### PR DESCRIPTION
This is a proposed new advisory format based on Markdown with embedded TOML front matter. See the relevant GitHub issue:

https://github.com/RustSec/advisory-db/issues/240

Uses triple backquotes + `toml` for the front matter delimiter, which renders correctly as syntax highlighted TOML on GitHub. This is a bit unusual way to specify front matter (typically it's YAML with `---` delimiters) but it seems to work ok.

The advisory `title` and `description` are moved out-of-band from the rest of the advisory into the underlying Markdown document. This allows it to render correctly on e.g. GitHub.

The implementation used in this PR isn't final, but ideally this is close to the final format. If it is, future clients will be compatible with the format after this PR is merged.

Rendered:

<img width="887" alt="Screen Shot 2020-05-03 at 10 39 41 AM" src="https://user-images.githubusercontent.com/797/80921409-1db91380-8d2b-11ea-8f6a-5ec384931d8f.png">
