### PR TITLE
v0.19.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.19.0] (2020-05-04)
+
+- Refactor package scopes ([#168])
+- Prototype V3 Advisory Format ([#167])
+- Bump dependencies to link `libgit2` dynamically ([#163])
+- Add `WarningInfo` and modify `Warning` struct ([#156])
+- Drop support for the V1 advisory format ([#154])
+
 ## [0.18.0] (2020-02-05)
 
 - Move yanked crate auditing to `cargo-audit` ([#147])
@@ -174,6 +182,12 @@
 
 - Initial release
 
+[0.19.0]: https://github.com/RustSec/rustsec-crate/pull/169
+[#168]: https://github.com/RustSec/rustsec-crate/pull/168
+[#167]: https://github.com/RustSec/rustsec-crate/pull/167
+[#163]: https://github.com/RustSec/rustsec-crate/pull/163
+[#156]: https://github.com/RustSec/rustsec-crate/pull/156
+[#154]: https://github.com/RustSec/rustsec-crate/pull/154
 [0.18.0]: https://github.com/RustSec/rustsec-crate/pull/148
 [#147]: https://github.com/RustSec/rustsec-crate/pull/147
 [0.17.1]: https://github.com/RustSec/rustsec-crate/pull/144

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustsec"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
@@ -29,7 +29,7 @@ thiserror = "1"
 toml = "0.5"
 
 [dependencies.cargo-edit]
-version = "= 0.6.0" # ensure `git2` dep matches when upgrading
+version = "0.6"
 optional = true
 default-features = false
 features = ["upgrade"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Docs][docs-image]][docs-link]
 [![Build Status][build-image]][build-link]
 [![Safety Dance][safety-image]][safety-link]
-[![dependency status][deps-image]][deps-link]
 ![MSRV][rustc-image]
 ![Apache 2.0 OR MIT licensed][license-image]
 [![Gitter Chat][gitter-image]][gitter-link]
@@ -52,8 +51,6 @@ additional terms or conditions.
 [build-link]: https://github.com/rustsec/rustsec-crate/actions
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[deps-image]: https://deps.rs/repo/github/RustSec/rustsec-crate/status.svg
-[deps-link]: https://deps.rs/repo/github/RustSec/rustsec-crate
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [gitter-image]: https://badges.gitter.im/badge.svg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.18.0"
+    html_root_url = "https://docs.rs/rustsec/0.19.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Refactor package scopes ([#168])
- Prototype V3 Advisory Format ([#167])
- Bump dependencies to link `libgit2` dynamically ([#163])
- Add `WarningInfo` and modify `Warning` struct ([#156])
- Drop support for the V1 advisory format ([#154])

[0.19.0]: https://github.com/RustSec/rustsec-crate/pull/169
[#168]: https://github.com/RustSec/rustsec-crate/pull/168
[#167]: https://github.com/RustSec/rustsec-crate/pull/167
[#163]: https://github.com/RustSec/rustsec-crate/pull/163
[#156]: https://github.com/RustSec/rustsec-crate/pull/156
[#154]: https://github.com/RustSec/rustsec-crate/pull/154