### PR TITLE
Make `WarningInfo` into a simple type alias

### DIFF
--- a/src/database/scope.rs
+++ b/src/database/scope.rs
@@ -55,7 +55,7 @@ impl Default for Package {
 }
 
 impl Package {
-    /// Creates a new [[Scope]] from a specific registry uri `source`
+    /// Creates a new [[`Package`]] scope from a specific registry URI
     pub fn from_registry(source: &str) -> Self {
         Registry::Private {
             uri: source.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! rustsec: Client library for the `RustSec` security advisory database
+//! `rustsec`: client library for the RustSec Security Advisory Database
 //!
 //! This crate is primarily intended for use with the cargo-audit tool:
 //!

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,5 +1,5 @@
 //! Vulnerabilities represent the interesection of the [`Advisory`] database
-//! and a particular [`Lockfile`].
+//! and a particular `Cargo.lock` file.
 
 use crate::{
     advisory::{self, affected::FunctionPath, Advisory},


### PR DESCRIPTION
Gets rid of the outer wrapper struct and makes `WarningInfo` a type alias of `Map`