### PR TITLE
.github: ignore RUSTSEC-2020-0016

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -42,4 +42,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny-warnings
+          args: --deny-warnings --ignore RUSTSEC-2020-0016


### PR DESCRIPTION
This is an unmaintained crate advisory for the `net2` crate, vicariously pulled in via `tokio` v0.2.

The "fix" will be an upgrade to `tokio` v0.3 when it's available, which switches to `socket2` (vicariously via `mio`).

Until then there's nothing we can do.