### PR TITLE
add 'unsound' informational advisory kind

### DIFF
--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -15,6 +15,11 @@ pub enum Informational {
     /// Crate is unmaintained / abandoned
     Unmaintained,
 
+    /// Crate is not [sound].
+    ///
+    /// [sound]: https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library
+    Unsound,
+
     /// Other types of informational advisories: left open-ended to add
     /// more of them in the future.
     Other(String),
@@ -26,6 +31,7 @@ impl Informational {
         match self {
             Informational::Notice => "notice",
             Informational::Unmaintained => "unmaintained",
+            Informational::Unsound => "unsound",
             Informational::Other(other) => other,
         }
     }
@@ -44,6 +50,7 @@ impl FromStr for Informational {
         Ok(match s {
             "notice" => Informational::Notice,
             "unmaintained" => Informational::Unmaintained,
+            "unsound" => Informational::Unsound,
             other => Informational::Other(other.to_owned()),
         })
     }

--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -17,7 +17,7 @@ pub enum Informational {
 
     /// Crate is not [sound], i.e., unsound.
     ///
-    /// A crate is unsound if, using its public API from safe code, it is possible to cause [Undefind Behavior].
+    /// A crate is unsound if, using its public API from safe code, it is possible to cause [Undefined Behavior].
     ///
     /// [sound]: https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library
     /// [Undefined Behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html

--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -15,9 +15,12 @@ pub enum Informational {
     /// Crate is unmaintained / abandoned
     Unmaintained,
 
-    /// Crate is not [sound].
+    /// Crate is not [sound], i.e., unsound.
+    ///
+    /// A crate is unsound if, using its public API from safe code, it is possible to cause [Undefind Behavior].
     ///
     /// [sound]: https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library
+    /// [Undefined Behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     Unsound,
 
     /// Other types of informational advisories: left open-ended to add

--- a/src/report.rs
+++ b/src/report.rs
@@ -195,7 +195,9 @@ pub fn find_warnings(db: &Database, lockfile: &Lockfile, settings: &Settings) ->
             .any(|info| Some(info) == advisory.informational.as_ref())
         {
             let warning_kind = match advisory.informational.as_ref().unwrap() {
-                advisory::Informational::Notice => warning::Kind::Informational,
+                advisory::Informational::Notice | advisory::Informational::Unsound => {
+                    warning::Kind::Informational
+                }
                 advisory::Informational::Unmaintained => warning::Kind::Unmaintained,
                 advisory::Informational::Other(_) => continue,
             };

--- a/src/report.rs
+++ b/src/report.rs
@@ -195,9 +195,8 @@ pub fn find_warnings(db: &Database, lockfile: &Lockfile, settings: &Settings) ->
             .any(|info| Some(info) == advisory.informational.as_ref())
         {
             let warning_kind = match advisory.informational.as_ref().unwrap() {
-                advisory::Informational::Notice | advisory::Informational::Unsound => {
-                    warning::Kind::Informational
-                }
+                advisory::Informational::Notice => warning::Kind::Informational,
+                advisory::Informational::Unsound => warning::Kind::Unsound,
                 advisory::Informational::Unmaintained => warning::Kind::Unmaintained,
                 advisory::Informational::Other(_) => continue,
             };

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -46,6 +46,10 @@ pub enum Kind {
     #[serde(rename = "unmaintained")]
     Unmaintained,
 
+    /// Unsound packages
+    #[serde(rename = "unsound")]
+    Unsound,
+
     /// Informational advisories
     #[serde(rename = "informational")]
     Informational,


### PR DESCRIPTION
Following the discussion in https://github.com/RustSec/advisory-db/issues/300 and [on Reddit](https://www.reddit.com/r/rust/comments/gidtpe/security_advisories_for_april_2020_rustqlite_os/), it seemed like many people were in favor of tracking known soundness violations in a manner similar to how we track unmaintained crates. I am very biased on the subject though, so let me know if I am moving too fast here. ;) I do not know what your usual decision procedures are.

Closes https://github.com/RustSec/advisory-db/issues/300.