### PR TITLE
Make `Informational` a #[non_exhausive] enum

### DIFF
--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -3,8 +3,7 @@
 //!
 //! This is run in CI at the time advisories are submitted.
 
-use super::{Advisory, Category, Informational};
-use chrono::Datelike;
+use super::{Advisory, Category};
 use std::{fmt, fs, path::Path};
 
 /// Lint information about a particular advisory
@@ -129,11 +128,16 @@ impl Linter {
                         message: Some("collection shouldn't be explicit; inferred by location"),
                     }),
                     "informational" => {
-                        if let Some(Informational::Other(other)) =
-                            &self.advisory.metadata.informational
-                        {
+                        let informational = self
+                            .advisory
+                            .metadata
+                            .informational
+                            .as_ref()
+                            .expect("parsed informational");
+
+                        if informational.is_other() {
                             self.errors.push(Error {
-                                kind: ErrorKind::value("informational", other.to_string()),
+                                kind: ErrorKind::value("informational", informational.as_str()),
                                 section: Some("advisory"),
                                 message: Some("unknown informational advisory type"),
                             });
@@ -151,8 +155,7 @@ impl Linter {
                         }
                     }
                     "date" => {
-                        let y1 =
-                            self.advisory.metadata.date.to_chrono_date().unwrap().year() as u32;
+                        let y1 = self.advisory.metadata.date.year();
 
                         if let Some(y2) = year {
                             if y1 != y2 {

--- a/src/report.rs
+++ b/src/report.rs
@@ -194,11 +194,14 @@ pub fn find_warnings(db: &Database, lockfile: &Lockfile, settings: &Settings) ->
             .iter()
             .any(|info| Some(info) == advisory.informational.as_ref())
         {
-            let warning_kind = match advisory.informational.as_ref().unwrap() {
-                advisory::Informational::Notice => warning::Kind::Informational,
-                advisory::Informational::Unsound => warning::Kind::Unsound,
-                advisory::Informational::Unmaintained => warning::Kind::Unmaintained,
-                advisory::Informational::Other(_) => continue,
+            let warning_kind = match advisory
+                .informational
+                .as_ref()
+                .expect("informational advisory")
+                .warning_kind()
+            {
+                Some(kind) => kind,
+                None => continue,
             };
 
             let warning = Warning::new(


### PR DESCRIPTION
Previously `Informational` was an enum exposed as a part of the public API, which makes the addition of any new variants a SemVer-breaking change.

~~This commit encapsulates the inner enum inside of an `Informational` struct with `is_*` predicate methods to check for the various categorizations, as well as adds a `warning_kind` method to handle the conversion to a `warning::Kind`.~~

This commit converts it to be `#[non_exhaustive]`, allowing it to ensure backwards compatibility even when new enum variants are added.

On that subject, `warning::Kind` should get the same treatment, however this commit leaves that for a follow-up.