### PR TITLE
Make `warning::Kind` a #[non_exhausive] enum; rename `Kind::Notice`

### DIFF
--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -75,7 +75,7 @@ impl Informational {
     /// Get a warning kind for this informational type (if applicable)
     pub fn warning_kind(&self) -> Option<warning::Kind> {
         match self {
-            Self::Notice => Some(warning::Kind::Informational),
+            Self::Notice => Some(warning::Kind::Notice),
             Self::Unmaintained => Some(warning::Kind::Unmaintained),
             Self::Unsound => Some(warning::Kind::Unsound),
             Self::Other(_) => None,


### PR DESCRIPTION
Following up from #194 which made `Informational` a non-exhaustive enum, this commit makes `warning::Kind` one as well to ensure future extensibility without breaking backwards compatibility.

It also adds predicate methods for the current types, and renames `Kind::Informational` (which is ambiguous) to `kind::Notice` to match the `Informational::Notice` variant.