### PR TITLE
Rename `obsolete` advisories to `yanked`

### DIFF
--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -169,9 +169,9 @@ impl Linter {
                             year = Some(y1);
                         }
                     }
-                    "patched_versions" | "unaffected_versions" => (), // TODO(tarcieri): deprecate
-                    "aliases" | "cvss" | "keywords" | "obsolete" | "package" | "references"
-                    | "title" | "description" => (),
+                    "patched_versions" | "unaffected_versions" | "obsolete" => (), // TODO(tarcieri): deprecate
+                    "aliases" | "cvss" | "keywords" | "package" | "references" | "title"
+                    | "description" | "yanked" => (),
                     _ => self.errors.push(Error {
                         kind: ErrorKind::key(key),
                         section: Some("advisory"),

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -62,12 +62,14 @@ pub struct Metadata {
     /// affecting a particular crate without failing the build.
     pub informational: Option<Informational>,
 
-    /// Is the advisory obsolete? Obsolete advisories will be ignored.
-    #[serde(default)]
-    pub obsolete: bool,
-
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,
+
+    /// Has this advisory (i.e. itself, regardless of the crate) been yanked?
+    ///
+    /// This can be used to soft-delete advisories which were filed in error.
+    #[serde(default)]
+    pub yanked: bool,
 
     /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
     // TODO(tarcieri): phase this out

--- a/src/database/query.rs
+++ b/src/database/query.rs
@@ -33,8 +33,9 @@ pub struct Query {
     /// Year associated with the advisory ID
     year: Option<u32>,
 
-    /// Query for obsolete advisories
-    obsolete: Option<bool>,
+    /// Query for yanked advisories (i.e. advisories which were soft-deleted
+    /// from the database, as opposed to yanked crates)
+    yanked: Option<bool>,
 
     /// Query for informational advisories
     informational: Option<bool>,
@@ -52,12 +53,12 @@ impl Query {
     /// Create a new query which uses the default scope rules for crates:
     ///
     /// - Only `Collection::Crates`
-    /// - Ignore obsolete advisories
+    /// - Ignore yanked advisories
     /// - Ignore informational advisories
     pub fn crate_scope() -> Self {
         Self::new()
             .collection(Collection::Crates)
-            .obsolete(false)
+            .yanked(false)
             .informational(false)
     }
 
@@ -112,10 +113,11 @@ impl Query {
         self
     }
 
-    /// Query for obsolete vulnerabilities. By default they will be omitted
-    /// from query results.
-    pub fn obsolete(mut self, setting: bool) -> Self {
-        self.obsolete = Some(setting);
+    /// Query for yanked advisories.
+    ///
+    /// By default they will be omitted from query results.
+    pub fn yanked(mut self, setting: bool) -> Self {
+        self.yanked = Some(setting);
         self
     }
 
@@ -176,8 +178,8 @@ impl Query {
             }
         }
 
-        if let Some(obsolete) = self.obsolete {
-            if obsolete != advisory.metadata.obsolete {
+        if let Some(yanked) = self.yanked {
+            if yanked != advisory.metadata.yanked {
                 return false;
             }
         }


### PR DESCRIPTION
The term `yanked` more clearly conveys that advisories flagged as such should be ignored.

This continues to allow `obsolete` advisories to pass the linter until we update them all to be `yanked` (there's only one flagged as such in the advisory DB anyway)