### PR TITLE
Remove legacy `patched_versions` and `unaffected_versions`

### DIFF
--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -169,9 +169,9 @@ impl Linter {
                             year = Some(y1);
                         }
                     }
-                    "patched_versions" | "unaffected_versions" | "obsolete" => (), // TODO(tarcieri): deprecate
                     "aliases" | "cvss" | "keywords" | "package" | "references" | "title"
                     | "description" | "yanked" => (),
+                    "obsolete" => (), // TODO(tarcieri): deprecate
                     _ => self.errors.push(Error {
                         kind: ErrorKind::key(key),
                         section: Some("advisory"),

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -3,7 +3,7 @@
 use super::{
     category::Category, date::Date, id::Id, informational::Informational, keyword::Keyword,
 };
-use crate::{collection::Collection, package, version::VersionReq};
+use crate::{collection::Collection, package};
 use serde::{Deserialize, Serialize};
 
 /// The `[advisory]` section of a RustSec security advisory
@@ -70,13 +70,4 @@ pub struct Metadata {
     /// This can be used to soft-delete advisories which were filed in error.
     #[serde(default)]
     pub yanked: bool,
-
-    /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
-    // TODO(tarcieri): phase this out
-    #[serde(default)]
-    pub(super) patched_versions: Vec<VersionReq>,
-
-    /// Versions which were never affected in the first place
-    #[serde(default)]
-    pub(super) unaffected_versions: Vec<VersionReq>,
 }


### PR DESCRIPTION
Advisories were migrated in https://github.com/RustSec/advisory-db/pull/238 and support for the "V1" format which used the was dropped in #154, however the fields themselves were missed. This commit removes them.