### PR TITLE
v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.20.1 (2020-06-14)
+## 0.21.0 (2020-06-23)
+### Added
+- `year`, `month`, and `day` methods to `advisory::Date` ([#191])
+- `unsound` informational advisory kind ([#189])
 
-- Add `advisory::Id::numerical_part()` ([#185])
+### Changed
+- Bump `crates-index` from 0.14 to 0.15 ([#183])
+- Rename `obsolete` advisories to `yanked` ([#196])
+- Rename `warning::Kind::Informational` to `::Notice` ([#195])
+- Make `warning::Kind` a `#[non_exhausive]` enum ([#195])
+- Make `Informational` a `#[non_exhausive]` enum ([#194])
+
+### Removed
+- Legacy `patched_versions` and `unaffected_versions` ([#197])
+
+[#197]: https://github.com/RustSec/rustsec-crate/pull/197
+[#196]: https://github.com/RustSec/rustsec-crate/pull/196
+[#195]: https://github.com/RustSec/rustsec-crate/pull/195
+[#194]: https://github.com/RustSec/rustsec-crate/pull/194
+[#191]: https://github.com/RustSec/rustsec-crate/pull/191
+[#189]: https://github.com/RustSec/rustsec-crate/pull/189
+[#183]: https://github.com/RustSec/rustsec-crate/pull/183
+
+## 0.20.1 (2020-06-14)
+### Added
+- `advisory::Id::numerical_part()` ([#185])
 
 [#185]: https://github.com/RustSec/rustsec-crate/pull/185
 
 ## 0.20.0 (2020-05-06)
-
+### Changed
 - Make `WarningInfo` into a simple type alias ([#170])
 
 [#170]: https://github.com/RustSec/rustsec-crate/pull/170

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.20.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.20.0"
+    html_root_url = "https://docs.rs/rustsec/0.21.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `year`, `month`, and `day` methods to `advisory::Date` ([#191])
- `unsound` informational advisory kind ([#189])

### Changed
- Bump `crates-index` from 0.14 to 0.15 ([#183])
- Rename `obsolete` advisories to `yanked` ([#196])
- Rename `warning::Kind::Informational` to `::Notice` ([#195])
- Make `warning::Kind` a `#[non_exhausive]` enum ([#195])
- Make `Informational` a `#[non_exhausive]` enum ([#194])

### Removed
- Legacy `patched_versions` and `unaffected_versions` ([#197])

[#197]: https://github.com/RustSec/rustsec-crate/pull/197
[#196]: https://github.com/RustSec/rustsec-crate/pull/196
[#195]: https://github.com/RustSec/rustsec-crate/pull/195
[#194]: https://github.com/RustSec/rustsec-crate/pull/194
[#191]: https://github.com/RustSec/rustsec-crate/pull/191
[#189]: https://github.com/RustSec/rustsec-crate/pull/189
[#183]: https://github.com/RustSec/rustsec-crate/pull/183