### PR TITLE
Refactor changes from `fetch` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs-err"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1223,7 @@ dependencies = [
  "chrono",
  "crates-index",
  "cvss",
+ "fs-err",
  "git2",
  "home",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ cargo-lock = { version = "5", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 crates-index = { version = "0.15.4", optional = true }
 cvss = { version = "1", features = ["serde"] }
+fs-err = "2.5"
 git2 = { version = "0.13", optional = true }
 home = { version = "0.5", optional = true }
 platforms = { version = "1", features = ["serde"] }

--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -18,9 +18,12 @@ pub use self::{
 };
 pub use cvss::Severity;
 
-use crate::error::{Error, ErrorKind};
+use crate::{
+    error::{Error, ErrorKind},
+    fs,
+};
 use serde::{Deserialize, Serialize};
-use std::{fs, path::Path, str::FromStr};
+use std::{path::Path, str::FromStr};
 
 /// RustSec Security Advisories
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -4,7 +4,8 @@
 //! This is run in CI at the time advisories are submitted.
 
 use super::{parser, Advisory, Category};
-use std::{fmt, fs, path::Path};
+use crate::fs;
+use std::{fmt, path::Path};
 
 /// Lint information about a particular advisory
 #[derive(Debug)]
@@ -52,7 +53,6 @@ impl Linter {
         // Get a raw TOML value representing the document for linting
         let toml_value = if is_v3 {
             let parts = parser::Parts::parse(&s)?;
-            dbg!(&parts);
             parts.front_matter.parse::<toml::Value>()?
         } else {
             s.parse::<toml::Value>()?

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -18,6 +18,11 @@ pub enum Collection {
 }
 
 impl Collection {
+    /// Get all collections as a slice
+    pub fn all() -> &'static [Self] {
+        &[Collection::Crates, Collection::Rust]
+    }
+
     /// Get a `str` representing the kind of package
     pub fn as_str(&self) -> &str {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod vulnerability;
 pub mod warning;
 
 pub use cargo_lock::{self, lockfile, package};
+pub use fs_err as fs;
 pub use platforms;
 pub use semver::{self, Version, VersionReq};
 
@@ -36,7 +37,6 @@ pub use crate::{
     database::Database,
     error::{Error, ErrorKind},
     report::Report,
-    repository::Repository,
     vulnerability::Vulnerability,
     warning::Warning,
 };

--- a/src/report.rs
+++ b/src/report.rs
@@ -112,11 +112,11 @@ pub struct DatabaseInfo {
 
     /// Git commit hash for the last commit to the database
     #[serde(rename = "last-commit")]
-    pub last_commit: String,
+    pub last_commit: Option<String>,
 
     /// Date when the advisory database was last committed to
     #[serde(rename = "last-updated")]
-    pub last_updated: DateTime<Utc>,
+    pub last_updated: Option<DateTime<Utc>>,
 }
 
 impl DatabaseInfo {
@@ -124,8 +124,8 @@ impl DatabaseInfo {
     pub fn new(db: &Database) -> Self {
         Self {
             advisory_count: db.iter().count(),
-            last_commit: db.latest_commit().commit_id.clone(),
-            last_updated: db.latest_commit().time,
+            last_commit: db.latest_commit().map(|c| c.commit_id.clone()),
+            last_updated: db.latest_commit().map(|c| c.time),
         }
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,15 +1,15 @@
 //! Repository handling for the RustSec advisory DB
 
+pub mod signature;
+
 #[cfg(feature = "fetch")]
 pub mod git;
 
-pub mod signature;
-
-use crate::Error;
-use signature::Signature;
-use std::path::PathBuf;
+#[cfg(feature = "fetch")]
+pub use self::git::GitRepository;
 
 use chrono::{DateTime, Utc};
+use signature::Signature;
 
 /// Information about a commit to the Git repository
 #[derive(Debug)]
@@ -32,13 +32,4 @@ pub struct Commit {
 
     /// Signed data to verify along with this commit
     signed_data: Option<Vec<u8>>,
-}
-
-/// Repository for a Rust advisory DB.
-pub trait Repository {
-    /// Get information about the latest commit to the repo
-    fn latest_commit(&self) -> Result<Commit, Error>;
-
-    /// Paths to all advisories located in the database
-    fn advisories(&self) -> Result<Vec<PathBuf>, Error>;
 }

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 
 static DEFAULT_DATABASE: Lazy<Mutex<Database>> = Lazy::new(|| {
     Mutex::new(
-        Database::load(&GitRepository::fetch_default_repo().unwrap())
+        Database::load_from_repo(&GitRepository::fetch_default_repo().unwrap())
             .expect("Should be fetchable."),
     )
 });

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 /// Happy path integration test (has online dependency on GitHub)
 #[test]
 fn happy_path() {
-    let db = Database::load(&git::GitRepository::fetch_default_repo().unwrap()).unwrap();
+    let db = Database::load_from_repo(&git::GitRepository::fetch_default_repo().unwrap()).unwrap();
     verify_rustsec_2017_0001(&db);
     verify_cve_2018_1000810(&db);
 }


### PR DESCRIPTION
PR #213 added a `fetch` feature and made `Repository` into a trait with `GitRepository` as the only implementer.

That's not really helpful for opening a local copy of the database though, so this commit adds a proper `Database::open` method that can load a database from a given directory.

It also removes the trait since it had no other impls and therefore wasn't very helpful. We can perhaps circle back on renaming `GitRepository` back to `Repository`, although it is more descriptive so perhaps it should stay.