### PR TITLE
advisory: mark the `parser` module as `pub`

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -8,9 +8,8 @@ pub mod informational;
 pub mod keyword;
 pub mod linter;
 pub mod metadata;
+pub mod parser;
 pub mod versions;
-
-mod parser;
 
 pub use self::{
     affected::Affected, category::Category, date::Date, id::Id, informational::Informational,

--- a/src/advisory/parser.rs
+++ b/src/advisory/parser.rs
@@ -5,7 +5,7 @@ use crate::error::{Error, ErrorKind};
 
 /// Parts of a parsed advisory
 #[derive(Copy, Clone, Debug)]
-pub(super) struct Parts<'a> {
+pub struct Parts<'a> {
     /// TOML front matter
     pub front_matter: &'a str,
 
@@ -21,7 +21,7 @@ pub(super) struct Parts<'a> {
 
 impl<'a> Parts<'a> {
     /// Parse a Markdown advisory into its component parts
-    pub(super) fn parse(advisory_data: &'a str) -> Result<Self, Error> {
+    pub fn parse(advisory_data: &'a str) -> Result<Self, Error> {
         if !advisory_data.starts_with("```toml") {
             let context = if advisory_data.len() > 20 {
                 &advisory_data[..20]


### PR DESCRIPTION
...so the admin tool can use it