### PR TITLE
v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.22.0 (2020-10-25)
+### Added
+- `fetch` feature ([#213], [#226])
+
+### Changed
+- Bump `cargo-lock` to v6; `semver` to v0.11 ([#244])
+- Make `advisory.title` and `advisory.description` struct fields ([#242])
+- Remove support for the V2 advisory format ([#238], [#242], [#243])
+- Mark the `advisory::parser` module as `pub` ([#240])
+- Bump `cargo-edit` to 0.7.0 ([#231])
+- Bump `crates-index` from 0.15.4 to 0.16.0 ([#237])
+- `advisory`: laxer function path handling ([#229])
+- `linter`: fully deprecate `obsolete` in favor of `yanked` ([#228])
+- `advisory`: `markdown` feature and `Advisory::description_html` ([#227])
+- `linter`: add support for V3 advisory format ([#225])
+- MSRV 1.41+ ([#217])
+- Bump `platforms` crate to v1 ([#210])
+
+### Fixed
+- `linter`: correctly handle crates with dashes in names ([#221])
+
+### Removed
+- `advisory.metadata.title` and `advisory.metadata.description` ([#242])
+
+[#244]: https://github.com/RustSec/rustsec-crate/pull/244
+[#243]: https://github.com/RustSec/rustsec-crate/pull/243
+[#242]: https://github.com/RustSec/rustsec-crate/pull/242
+[#240]: https://github.com/RustSec/rustsec-crate/pull/240
+[#238]: https://github.com/RustSec/rustsec-crate/pull/238
+[#237]: https://github.com/RustSec/rustsec-crate/pull/237
+[#231]: https://github.com/RustSec/rustsec-crate/pull/231
+[#229]: https://github.com/RustSec/rustsec-crate/pull/229
+[#228]: https://github.com/RustSec/rustsec-crate/pull/228
+[#227]: https://github.com/RustSec/rustsec-crate/pull/227
+[#226]: https://github.com/RustSec/rustsec-crate/pull/226
+[#225]: https://github.com/RustSec/rustsec-crate/pull/225
+[#221]: https://github.com/RustSec/rustsec-crate/pull/221
+[#217]: https://github.com/RustSec/rustsec-crate/pull/217
+[#213]: https://github.com/RustSec/rustsec-crate/pull/213
+[#210]: https://github.com/RustSec/rustsec-crate/pull/210
+
 ## 0.21.0 (2020-06-23)
 ### Added
 - `year`, `month`, and `day` methods to `advisory::Date` ([#191])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustsec"
-version = "0.22.0-pre3"
+version = "0.22.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.22.0-pre3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.22.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Safety Dance][safety-image]][safety-link]
 ![MSRV][rustc-image]
 ![Apache 2.0 OR MIT licensed][license-image]
-[![Gitter Chat][gitter-image]][gitter-link]
+[![Project Chat][chat-image]][chat-link]
 
 Client library for accessing the [RustSec Security Advisory Database]:
 fetches the [advisory-db] (or other compatible) git repository and
@@ -56,8 +56,8 @@ additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[gitter-image]: https://badges.gitter.im/badge.svg
-[gitter-link]: https://gitter.im/RustSec/Lobby
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/
 
 [//]: # (general links)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.22.0-pre3"
+    html_root_url = "https://docs.rs/rustsec/0.22.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -17,14 +17,16 @@ pub mod error;
 pub mod advisory;
 pub mod collection;
 pub mod database;
-#[cfg(feature = "fix")]
-pub mod fixer;
-#[cfg(feature = "fetch")]
-pub mod registry;
 pub mod report;
 pub mod repository;
 pub mod vulnerability;
 pub mod warning;
+
+#[cfg(feature = "fix")]
+pub mod fixer;
+
+#[cfg(feature = "fetch")]
+pub mod registry;
 
 pub use cargo_lock::{self, lockfile, package};
 pub use fs_err as fs;


### PR DESCRIPTION
### Added
- `fetch` feature ([#213], [#226])

### Changed
- Bump `cargo-lock` to v6; `semver` to v0.11 ([#244])
- Make `advisory.title` and `advisory.description` struct fields ([#242])
- Remove support for the V2 advisory format ([#238], [#242], [#243])
- Mark the `advisory::parser` module as `pub` ([#240])
- Bump `cargo-edit` to 0.7.0 ([#231])
- Bump `crates-index` from 0.15.4 to 0.16.0 ([#237])
- `advisory`: laxer function path handling ([#229])
- `linter`: fully deprecate `obsolete` in favor of `yanked` ([#228])
- `advisory`: `markdown` feature and `Advisory::description_html` ([#227])
- `linter`: add support for V3 advisory format ([#225])
- MSRV 1.41+ ([#217])
- Bump `platforms` crate to v1 ([#210])

### Fixed
- `linter`: correctly handle crates with dashes in names ([#221])

### Removed
- `advisory.metadata.title` and `advisory.metadata.description` ([#242])

[#244]: https://github.com/RustSec/rustsec-crate/pull/244
[#243]: https://github.com/RustSec/rustsec-crate/pull/243
[#242]: https://github.com/RustSec/rustsec-crate/pull/242
[#240]: https://github.com/RustSec/rustsec-crate/pull/240
[#238]: https://github.com/RustSec/rustsec-crate/pull/238
[#237]: https://github.com/RustSec/rustsec-crate/pull/237
[#231]: https://github.com/RustSec/rustsec-crate/pull/231
[#229]: https://github.com/RustSec/rustsec-crate/pull/229
[#228]: https://github.com/RustSec/rustsec-crate/pull/228
[#227]: https://github.com/RustSec/rustsec-crate/pull/227
[#226]: https://github.com/RustSec/rustsec-crate/pull/226
[#225]: https://github.com/RustSec/rustsec-crate/pull/225
[#221]: https://github.com/RustSec/rustsec-crate/pull/221
[#217]: https://github.com/RustSec/rustsec-crate/pull/217
[#213]: https://github.com/RustSec/rustsec-crate/pull/213
[#210]: https://github.com/RustSec/rustsec-crate/pull/210