### PR TITLE
v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.22.0 (2020-10-25)
+## 0.22.1 (2020-10-26)
+### Changed
+- Refactor `Advisory` and `VulnerabilityInfo` ([#246])
+
+[#246]: https://github.com/RustSec/rustsec-crate/pull/246
+
+## 0.22.0 (2020-10-25) [YANKED]
 ### Added
 - `fetch` feature ([#213], [#226])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustsec"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.22.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.22.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.22.0"
+    html_root_url = "https://docs.rs/rustsec/0.22.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
This is technically a SemVer breaking release. Since v0.22.0 was just published, it will be yanked.

### Changed
- Refactor `Advisory` and `VulnerabilityInfo` ([#246])

[#246]: https://github.com/RustSec/rustsec-crate/pull/246