### PR TITLE
Revert "Refactor Advisory type handling (#246)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "once_cell",
  "platforms",
  "semver 0.11.0",
- "semver-parser 0.10.0",
  "serde",
  "smol_str",
  "tempfile",

--- a/src/advisory/informational.rs
+++ b/src/advisory/informational.rs
@@ -42,26 +42,17 @@ impl Informational {
 
     /// Is this informational advisory a `notice`?
     pub fn is_notice(&self) -> bool {
-        match self {
-            Self::Notice => true,
-            _ => false,
-        }
+        *self == Self::Notice
     }
 
     /// Is this informational advisory for an `unmaintained` crate?
     pub fn is_unmaintained(&self) -> bool {
-        match self {
-            Self::Unmaintained => true,
-            _ => false,
-        }
+        *self == Self::Unmaintained
     }
 
     /// Is this informational advisory for an `unsound` crate?
     pub fn is_unsound(&self) -> bool {
-        match self {
-            Self::Unsound => true,
-            _ => false,
-        }
+        *self == Self::Unsound
     }
 
     /// Is this informational advisory of an unknown kind?

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -15,6 +15,14 @@ pub struct Metadata {
     /// Name of affected crate
     pub package: package::Name,
 
+    /// One-liner description of a vulnerability
+    #[serde(default)]
+    pub title: String,
+
+    /// Extended description of a vulnerability
+    #[serde(default)]
+    pub description: String,
+
     /// Date this advisory was officially issued
     pub date: Date,
 

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -26,7 +26,7 @@ impl Fixer {
         dry_run: bool,
     ) -> Result<VersionReq, Error> {
         // TODO(tarcieri): find semver-compatible fix?
-        let version_req = match vulnerability.advisory.versions.patched.get(0) {
+        let version_req = match vulnerability.versions.patched.get(0) {
             Some(req) => req,
             None => fail!(ErrorKind::Version, "no fixed version available"),
         };

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -2,15 +2,22 @@
 //! and a particular `Cargo.lock` file.
 
 use crate::{
-    advisory::{affected::FunctionPath, Advisory},
+    advisory::{self, affected::FunctionPath, Advisory},
     package::Package,
 };
+use serde::{Deserialize, Serialize};
 
-/// Vulnerability: security advisory and the package which is impacted by it
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// A vulnerable package and the associated advisory
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Vulnerability {
-    /// Advisory
-    pub advisory: Advisory,
+    /// Security advisory for which the package is vulnerable
+    pub advisory: advisory::Metadata,
+
+    /// Versions impacted by this vulnerability
+    pub versions: advisory::Versions,
+
+    /// More specific information about what this advisory affects (if available)
+    pub affected: Option<advisory::Affected>,
 
     /// Vulnerable package
     pub package: Package,
@@ -20,14 +27,16 @@ impl Vulnerability {
     /// Create `Vulnerability` about a given [`Advisory`] and [`Package`]
     pub fn new(advisory: &Advisory, package: &Package) -> Self {
         Self {
-            advisory: advisory.clone(),
+            advisory: advisory.metadata.clone(),
+            versions: advisory.versions.clone(),
+            affected: advisory.affected.clone(),
             package: package.clone(),
         }
     }
 
     /// Get the set of functions affected by this vulnerability (if available)
     pub fn affected_functions(&self) -> Option<Vec<FunctionPath>> {
-        self.advisory.affected.as_ref().and_then(|affected| {
+        self.affected.as_ref().and_then(|affected| {
             if affected.functions.is_empty() {
                 None
             } else {

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,7 +1,7 @@
 //! Warnings sourced from the Advisory DB
 
 use crate::error::{Error, ErrorKind};
-use crate::{advisory::Advisory, package::Package};
+use crate::{advisory, package::Package};
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
@@ -15,49 +15,46 @@ pub struct Warning {
     pub package: Package,
 
     /// Source advisory
-    pub advisory: Option<Advisory>,
+    pub advisory: Option<advisory::Metadata>,
+
+    /// Versions impacted by this warning
+    pub versions: Option<advisory::Versions>,
 }
 
 impl Warning {
     /// Create `Warning` of the given kind
-    pub fn new(kind: Kind, package: &Package, advisory: Option<Advisory>) -> Self {
+    pub fn new(
+        kind: Kind,
+        package: &Package,
+        advisory: Option<advisory::Metadata>,
+        versions: Option<advisory::Versions>,
+    ) -> Self {
         Self {
             kind,
             package: package.clone(),
             advisory,
+            versions,
         }
     }
 
     /// Is this a warning a `notice` about a crate?
     pub fn is_notice(&self) -> bool {
-        match self.kind {
-            Kind::Notice => true,
-            _ => false,
-        }
+        self.kind == Kind::Notice
     }
 
     /// Is this a warning about an `unmaintained` crate?
     pub fn is_unmaintained(&self) -> bool {
-        match self.kind {
-            Kind::Unmaintained => true,
-            _ => false,
-        }
+        self.kind == Kind::Unmaintained
     }
 
     /// Is this a warning about an `unsound` crate?
     pub fn is_unsound(&self) -> bool {
-        match self.kind {
-            Kind::Unmaintained => true,
-            _ => false,
-        }
+        self.kind == Kind::Unsound
     }
 
     /// Is this a warning about a yanked crate?
     pub fn is_yanked(&self) -> bool {
-        match self.kind {
-            Kind::Unmaintained => true,
-            _ => false,
-        }
+        self.kind == Kind::Yanked
     }
 }
 

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -19,9 +19,9 @@ fn parse_metadata() {
     let advisory = load_example_advisory();
     assert_eq!(advisory.metadata.id.as_str(), "RUSTSEC-2001-2101");
     assert_eq!(advisory.metadata.package.as_str(), "base");
-    assert_eq!(advisory.title, "All your base are belong to us");
+    assert_eq!(advisory.title(), "All your base are belong to us");
     assert_eq!(
-        advisory.description,
+        advisory.description(),
         "You have no chance to survive. Make your time."
     );
     assert_eq!(advisory.metadata.date.as_str(), "2001-02-03");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -35,11 +35,11 @@ fn verify_rustsec_2017_0001(db: &Database) {
         "https://github.com/dnaq/sodiumoxide/issues/154"
     );
     assert_eq!(
-        example_advisory.title,
+        example_advisory.title(),
         "scalarmult() vulnerable to degenerate public keys"
     );
     assert_eq!(
-        &example_advisory.description[0..30],
+        &example_advisory.description()[0..30],
         "The `scalarmult()` function in"
     );
     assert_eq!(
@@ -74,11 +74,11 @@ fn verify_cve_2018_1000810(db: &Database) {
         "https://groups.google.com/forum/#!topic/rustlang-security-announcements/CmSuTm-SaU0"
     );
     assert_eq!(
-        example_advisory.title,
+        example_advisory.title(),
         "Buffer overflow vulnerability in str::repeat()"
     );
     assert_eq!(
-        &example_advisory.description[0..30],
+        &example_advisory.description()[0..30],
         "The Rust team was recently not"
     );
     assert_eq!(


### PR DESCRIPTION
This reverts commit 22ba1269b580c16aa7bc5f1a561f97e15c31274e.

Though long term this is probably a good change, for now it's causing breaking changes to the JSON structure that haven't been fully thought out.

This reverts until we have a plan for a new JSON format, possibly one that can preserve the legacy format in a backwards-compatible way.