### PR TITLE
Rename `references` to `related`

### DIFF
--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -181,8 +181,8 @@ impl Linter {
                             year = Some(y1);
                         }
                     }
-                    "aliases" | "cvss" | "keywords" | "package" | "references" | "title"
-                    | "description" | "yanked" => (),
+                    "aliases" | "cvss" | "keywords" | "package" | "references" | "related"
+                    | "title" | "description" | "yanked" => (),
                     _ => self.errors.push(Error {
                         kind: ErrorKind::key(key),
                         section: Some("advisory"),

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -30,10 +30,10 @@ pub struct Metadata {
     #[serde(default)]
     pub aliases: Vec<Id>,
 
-    /// Advisory IDs which are related to this advisory (use `aliases` if it
-    /// is the same vulnerability syndicated to a different database)
+    /// Advisory IDs which are related to this advisory.
+    /// (use `aliases` for the same vulnerability syndicated to other databases)
     #[serde(default)]
-    pub references: Vec<Id>,
+    pub related: Vec<Id>,
 
     /// Collection this advisory belongs to. This isn't intended to be
     /// explicitly specified in the advisory, but rather is auto-populated


### PR DESCRIPTION
Related: RustSec/advisory-db#429

This renames the current `references` field containing related vulnerability IDs (supporting multiple known schemas) to `related`, opening up the `references` keyword to be used for a list of informational URLs.