### PR TITLE
Remove `markdown` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,24 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "comrak"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d325e4f2ffff52ca77d995bb675494d5364aa332499d5f7c7fbb28c25e671f6"
-dependencies = [
- "entities",
- "lazy_static",
- "pest",
- "pest_derive",
- "regex",
- "shell-words",
- "twoway",
- "typed-arena",
- "unicode_categories",
- "xdg",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,12 +374,6 @@ checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "entities"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "env_proxy"
@@ -1386,7 +1362,6 @@ dependencies = [
  "cargo-edit",
  "cargo-lock",
  "chrono",
- "comrak",
  "crates-index",
  "cvss",
  "fs-err",
@@ -1532,12 +1507,6 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "slab"
@@ -1826,22 +1795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "twoway"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
-name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
-
-[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,12 +1805,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"
@@ -1903,12 +1850,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unreachable"
@@ -2116,9 +2057,3 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 cargo-lock = { version = "6", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
-comrak = { version = "0.8", optional = true, default-features = false }
 crates-index = { version = "0.16.2", optional = true }
 cvss = { version = "1", features = ["serde"] }
 fs-err = "2.5"
@@ -45,7 +44,6 @@ once_cell = "1.5.2"
 default = ["fetch"]
 fetch = ["crates-index", "git2", "home"]
 fix = ["cargo-edit", "semver-parser"]
-markdown = ["comrak"]
 dependency-tree = ["cargo-lock/dependency-tree"]
 vendored-openssl = ["git2/vendored-openssl"]
 

--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -66,12 +66,6 @@ impl Advisory {
         self.metadata.description.as_ref()
     }
 
-    /// Get the description of this advisory as HTML rendered from Markdown
-    #[cfg(feature = "markdown")]
-    pub fn description_html(&self) -> String {
-        comrak::markdown_to_html(&self.description(), &Default::default())
-    }
-
     /// Get advisory date
     pub fn date(&self) -> &Date {
         &self.metadata.date


### PR DESCRIPTION
...with the goal of releasing a 1.0 `rustsec` crate which doesn't expose any non-1.0 crates as part of its public API.

`comrak` is not 1.0 yet and we're not using the `markdown` feature (the goal was to use it for generating the web site, which can still happen entirely within the `rustsec-admin` app)