### PR TITLE
Use `url` crate to parse metadata URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -1870,6 +1871,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1", features = ["serde_derive"] }
 smol_str = "=0.1.16" # smol_str 0.1.17 requires Rust 1.46+
 thiserror = "1"
 toml = "0.5"
+url = { version = "2", features = ["serde"] }
 
 [dependencies.cargo-edit]
 version = "0.7"

--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use crate::{collection::Collection, package};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 /// The `[advisory]` section of a RustSec security advisory
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -63,7 +64,7 @@ pub struct Metadata {
     pub informational: Option<Informational>,
 
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
-    pub url: Option<String>,
+    pub url: Option<Url>,
 
     /// Has this advisory (i.e. itself, regardless of the crate) been yanked?
     ///

--- a/tests/advisories.rs
+++ b/tests/advisories.rs
@@ -26,7 +26,7 @@ fn parse_metadata() {
     );
     assert_eq!(advisory.metadata.date.as_str(), "2001-02-03");
     assert_eq!(
-        advisory.metadata.url.unwrap(),
+        advisory.metadata.url.unwrap().to_string(),
         "https://www.youtube.com/watch?v=jQE66WA2s-A"
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -31,7 +31,7 @@ fn verify_rustsec_2017_0001(db: &Database) {
     );
     assert_eq!(example_advisory.metadata.date.as_str(), "2017-01-26");
     assert_eq!(
-        example_advisory.metadata.url.as_ref().unwrap(),
+        example_advisory.metadata.url.as_ref().unwrap().to_string(),
         "https://github.com/dnaq/sodiumoxide/issues/154"
     );
     assert_eq!(
@@ -70,7 +70,7 @@ fn verify_cve_2018_1000810(db: &Database) {
     );
     assert_eq!(example_advisory.metadata.date.as_str(), "2018-09-21");
     assert_eq!(
-        example_advisory.metadata.url.as_ref().unwrap(),
+        example_advisory.metadata.url.as_ref().unwrap().to_string(),
         "https://groups.google.com/forum/#!topic/rustlang-security-announcements/CmSuTm-SaU0"
     );
     assert_eq!(


### PR DESCRIPTION
Previously it was parsed as a `String`