### PR TITLE
Replace `chrono` with `humantime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -87,6 +87,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -204,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 dependencies = [
  "jobserver",
 ]
@@ -232,7 +238,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
  "time",
  "winapi 0.3.9",
 ]
@@ -263,6 +268,16 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -353,12 +368,6 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
@@ -528,7 +537,7 @@ dependencies = [
  "futures-io",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "slab",
 ]
@@ -676,6 +685,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,7 +716,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "socket2",
  "tokio",
  "tower-service",
@@ -1113,11 +1138,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1133,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1147,6 +1172,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1304,11 +1335,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1325,7 +1356,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "serde",
  "serde_urlencoded",
  "tokio",
@@ -1333,6 +1364,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
  "winreg",
 ]
@@ -1343,7 +1375,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -1361,12 +1393,13 @@ version = "0.22.2"
 dependencies = [
  "cargo-edit",
  "cargo-lock",
- "chrono",
  "crates-index",
  "cvss",
  "fs-err",
  "git2",
  "home",
+ "humantime",
+ "humantime-serde",
  "once_cell",
  "platforms",
  "semver 0.11.0",
@@ -1394,6 +1427,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "security-framework"
@@ -1487,14 +1526,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url",
 ]
 
 [[package]]
@@ -1533,11 +1572,11 @@ checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1628,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1686,15 +1725,24 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -1704,7 +1752,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "slab",
 ]
 
@@ -1728,7 +1776,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -1766,7 +1814,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-core",
 ]
 
@@ -1827,18 +1875,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"
@@ -1987,6 +2035,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,18 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 cargo-lock = { version = "6", default-features = false }
-chrono = { version = "0.4", features = ["serde"] }
 crates-index = { version = "0.16.2", optional = true }
 cvss = { version = "1", features = ["serde"] }
 fs-err = "2.5"
 git2 = { version = "0.13", optional = true }
 home = { version = "0.5", optional = true }
+humantime = { version = "2", optional = true }
+humantime-serde = { version = "1", optional = true }
 platforms = { version = "1", features = ["serde"] }
 semver = { version = "0.11", features = ["serde"] }
 semver-parser = { version = "=0.10.0", optional = true } # workardound for build failure?!
 serde = { version = "1", features = ["serde_derive"] }
-smol_str = "=0.1.17" # smol_str 0.1.17 requires Rust 1.46+
+smol_str = "=0.1.17" # Pinned to avoid MSRV breakages
 thiserror = "1"
 toml = "0.5"
 url = { version = "2", features = ["serde"] }
@@ -43,7 +44,7 @@ once_cell = "1.5.2"
 
 [features]
 default = ["fetch"]
-fetch = ["crates-index", "git2", "home"]
+fetch = ["crates-index", "git2", "home", "humantime", "humantime-serde"]
 fix = ["cargo-edit", "semver-parser"]
 dependency-tree = ["cargo-lock/dependency-tree"]
 vendored-openssl = ["git2/vendored-openssl"]

--- a/src/advisory/date.rs
+++ b/src/advisory/date.rs
@@ -2,7 +2,6 @@
 
 use crate::error::{Error, ErrorKind};
 
-use chrono::{self, NaiveDate, Utc};
 use serde::{de, Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -35,12 +34,6 @@ impl Date {
     /// Borrow this date as a string reference
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
-    }
-
-    /// Convert an advisory RFC 3339 date into a `chrono::Date`
-    pub fn to_chrono_date(&self) -> Result<chrono::Date<Utc>, Error> {
-        let date = NaiveDate::parse_from_str(&self.0, "%Y-%m-%d")?;
-        Ok(chrono::Date::from_utc(date, Utc))
     }
 
     /// Get a specific component of the date by numerical offset

--- a/src/database.rs
+++ b/src/database.rs
@@ -15,13 +15,12 @@ use crate::{
     error::Error,
     fs,
     lockfile::Lockfile,
-    repository::Commit,
     vulnerability::Vulnerability,
 };
 use std::path::Path;
 
 #[cfg(feature = "fetch")]
-use crate::repository::GitRepository;
+use crate::repository::{git::Commit, GitRepository};
 
 /// Iterator over entries in the database
 pub type Iter<'a> = std::slice::Iter<'a, Advisory>;
@@ -39,6 +38,7 @@ pub struct Database {
     crate_index: Index,
 
     /// Information about the last git commit to the database
+    #[cfg(feature = "fetch")]
     latest_commit: Option<Commit>,
 }
 
@@ -81,6 +81,7 @@ impl Database {
             advisories,
             crate_index,
             rust_index,
+            #[cfg(feature = "fetch")]
             latest_commit: None,
         })
     }
@@ -171,6 +172,7 @@ impl Database {
     }
 
     /// Get information about the latest commit to the repo
+    #[cfg(feature = "fetch")]
     pub fn latest_commit(&self) -> Option<&Commit> {
         self.latest_commit.as_ref()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,12 +113,6 @@ impl From<cargo_edit::Error> for Error {
     }
 }
 
-impl From<chrono::ParseError> for Error {
-    fn from(other: chrono::ParseError) -> Self {
-        format_err!(ErrorKind::Parse, &other)
-    }
-}
-
 impl From<fmt::Error> for Error {
     fn from(other: fmt::Error) -> Self {
         format_err!(ErrorKind::Io, &other)

--- a/src/report.rs
+++ b/src/report.rs
@@ -13,13 +13,16 @@ use crate::{
     warning::{self, Warning},
     Map,
 };
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "fetch")]
+use crate::repository::git;
 
 /// Vulnerability report for a given lockfile
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Report {
     /// Information about the advisory database
+    #[cfg(feature = "fetch")]
     pub database: DatabaseInfo,
 
     /// Information about the audited lockfile
@@ -49,6 +52,7 @@ impl Report {
         let warnings = find_warnings(db, lockfile, settings);
 
         Self {
+            #[cfg(feature = "fetch")]
             database: DatabaseInfo::new(db),
             lockfile: LockfileInfo::new(lockfile),
             settings: settings.clone(),
@@ -104,6 +108,7 @@ impl Settings {
 }
 
 /// Information about the advisory database
+#[cfg(feature = "fetch")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DatabaseInfo {
     /// Number of advisories in the database
@@ -116,16 +121,17 @@ pub struct DatabaseInfo {
 
     /// Date when the advisory database was last committed to
     #[serde(rename = "last-updated")]
-    pub last_updated: Option<DateTime<Utc>>,
+    pub last_updated: Option<git::Timestamp>,
 }
 
+#[cfg(feature = "fetch")]
 impl DatabaseInfo {
     /// Create database information from the advisory db
     pub fn new(db: &Database) -> Self {
         Self {
             advisory_count: db.iter().count(),
             last_commit: db.latest_commit().map(|c| c.commit_id.clone()),
-            last_updated: db.latest_commit().map(|c| c.time),
+            last_updated: db.latest_commit().map(|c| c.timestamp),
         }
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,29 +7,3 @@ pub mod git;
 
 #[cfg(feature = "fetch")]
 pub use self::git::GitRepository;
-
-use chrono::{DateTime, Utc};
-use signature::Signature;
-
-/// Information about a commit to the Git repository
-#[derive(Debug)]
-pub struct Commit {
-    /// ID (i.e. SHA-1 hash) of the latest commit
-    pub commit_id: String,
-
-    /// Information about the author of a commit
-    pub author: String,
-
-    /// Summary message for the commit
-    pub summary: String,
-
-    /// Commit time in number of seconds since the UNIX epoch
-    pub time: DateTime<Utc>,
-
-    /// Signature on the commit (mandatory for Repository::fetch)
-    // TODO: actually verify signatures
-    pub signature: Option<Signature>,
-
-    /// Signed data to verify along with this commit
-    signed_data: Option<Vec<u8>>,
-}

--- a/src/repository/git/timestamp.rs
+++ b/src/repository/git/timestamp.rs
@@ -1,0 +1,43 @@
+//! Git timestamps
+
+use serde::{Deserialize, Serialize};
+pub use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Number of days after which the repo will be considered stale
+/// (90 days)
+pub const STALE_AFTER: Duration = Duration::from_secs(90 * 86400);
+
+/// Git timestamps
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct Timestamp {
+    /// Inner timestamp value
+    #[serde(with = "humantime_serde")]
+    inner: SystemTime,
+}
+
+impl Timestamp {
+    /// Create a new timestamp from a Unix time in seconds
+    pub fn new(unix_secs: u64) -> Self {
+        Timestamp {
+            inner: UNIX_EPOCH + Duration::from_secs(unix_secs),
+        }
+    }
+
+    /// Is this timestamp "fresh" as in the database has been updated recently
+    /// (i.e. 90 days, per the `STALE_AFTER` constant)
+    pub fn is_fresh(self) -> bool {
+        self.inner > SystemTime::now().checked_sub(STALE_AFTER).unwrap()
+    }
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(system_time: SystemTime) -> Timestamp {
+        Timestamp { inner: system_time }
+    }
+}
+
+impl From<Timestamp> for SystemTime {
+    fn from(timestamp: Timestamp) -> SystemTime {
+        timestamp.inner
+    }
+}


### PR DESCRIPTION
Previously `chrono` types were part of the public API. However, after many years `chrono` still isn't a 1.0 crate, and we'd like to release a 1.0 version of the `rustsec` crate.

The only functionality we use from `chrono` is RFC 3339. The `humantime` crate implements this, makes it easy to keep the conversions out of the public API, and is post-1.0. It's also smaller, faster, and still widely used in the Rust ecosystem (11 million downloads)