### PR TITLE
Re-add advisory `references` as a URL list

### DIFF
--- a/src/advisory/metadata.rs
+++ b/src/advisory/metadata.rs
@@ -66,6 +66,10 @@ pub struct Metadata {
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<Url>,
 
+    /// Additional reference URLs with more information related to this advisory
+    #[serde(default)]
+    pub references: Vec<Url>,
+
     /// Has this advisory (i.e. itself, regardless of the crate) been yanked?
     ///
     /// This can be used to soft-delete advisories which were filed in error.


### PR DESCRIPTION
See also: RustSec/advisory-db#429

Adds support for parsing a list of URLs included in an advisory.

The `url` field remains the primary URL, however `references` can now contain multiple links with additional information.