### PR TITLE
Mark enums as non_exhaustive

### DIFF
--- a/src/advisory/category.rs
+++ b/src/advisory/category.rs
@@ -14,6 +14,7 @@ use std::{fmt, str::FromStr};
 ///
 /// [1]: https://github.com/RustSec/advisory-db/blob/master/CONTRIBUTING.md#criteria
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum Category {
     /// Execution of arbitrary code allowing an attacker to gain partial or
     /// total control of an impacted computer system.

--- a/src/advisory/id.rs
+++ b/src/advisory/id.rs
@@ -172,6 +172,7 @@ impl<'de> Deserialize<'de> for Id {
 
 /// Known kinds of advisory IDs
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum Kind {
     /// Our advisory namespace
     RUSTSEC,

--- a/src/advisory/linter.rs
+++ b/src/advisory/linter.rs
@@ -297,6 +297,7 @@ impl fmt::Display for Error {
 
 /// Lint errors
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Advisory is structurally malformed
     Malformed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,7 @@ impl std::error::Error for Error {}
 
 /// Custom error type for this library
 #[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Invalid argument or parameter
     #[error("bad parameter")]


### PR DESCRIPTION
Adds a `#[non_exhaustive]` attribute to any enums we may potentially want to expand in the future.