### PR TITLE
Rename `fetch` Cargo feature to `git`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ tempfile = "3"
 once_cell = "1.5.2"
 
 [features]
-default = ["fetch"]
-fetch = ["crates-index", "git2", "home", "humantime", "humantime-serde"]
+default = ["git"]
 fix = ["cargo-edit", "semver-parser"]
+git = ["crates-index", "git2", "home", "humantime", "humantime-serde"]
 dependency-tree = ["cargo-lock/dependency-tree"]
 vendored-openssl = ["git2/vendored-openssl"]
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use std::path::Path;
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 use crate::repository::{git::Commit, GitRepository};
 
 /// Iterator over entries in the database
@@ -38,7 +38,7 @@ pub struct Database {
     crate_index: Index,
 
     /// Information about the last git commit to the database
-    #[cfg(feature = "fetch")]
+    #[cfg(feature = "git")]
     latest_commit: Option<Commit>,
 }
 
@@ -81,13 +81,13 @@ impl Database {
             advisories,
             crate_index,
             rust_index,
-            #[cfg(feature = "fetch")]
+            #[cfg(feature = "git")]
             latest_commit: None,
         })
     }
 
     /// Load [`Database`] from the given [`GitRepository`]
-    #[cfg(feature = "fetch")]
+    #[cfg(feature = "git")]
     pub fn load_from_repo(repo: &GitRepository) -> Result<Self, Error> {
         let mut db = Self::open(repo.path())?;
         db.latest_commit = Some(repo.latest_commit()?);
@@ -95,7 +95,7 @@ impl Database {
     }
 
     /// Fetch the default advisory database from GitHub
-    #[cfg(feature = "fetch")]
+    #[cfg(feature = "git")]
     pub fn fetch() -> Result<Self, Error> {
         GitRepository::fetch_default_repo().and_then(|repo| Self::load_from_repo(&repo))
     }
@@ -172,7 +172,7 @@ impl Database {
     }
 
     /// Get information about the latest commit to the repo
-    #[cfg(feature = "fetch")]
+    #[cfg(feature = "git")]
     pub fn latest_commit(&self) -> Option<&Commit> {
         self.latest_commit.as_ref()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,7 +120,7 @@ impl From<fmt::Error> for Error {
     }
 }
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 impl From<git2::Error> for Error {
     fn from(other: git2::Error) -> Self {
         format_err!(ErrorKind::Repo, &other)
@@ -133,7 +133,7 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 impl From<crates_index::Error> for Error {
     fn from(other: crates_index::Error) -> Self {
         format_err!(ErrorKind::Registry, "{}", other)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod warning;
 #[cfg(feature = "fix")]
 pub mod fixer;
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 pub mod registry;
 
 pub use cargo_lock::{self, lockfile, package};
@@ -43,7 +43,7 @@ pub use crate::{
     warning::Warning,
 };
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 pub use crate::repository::git::GitRepository;
 
 // Use BTreeMap and BTreeSet as our map and set types

--- a/src/report.rs
+++ b/src/report.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 use std::time::SystemTime;
 
 /// Vulnerability report for a given lockfile
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Report {
     /// Information about the advisory database
-    #[cfg(feature = "fetch")]
+    #[cfg(feature = "git")]
     pub database: DatabaseInfo,
 
     /// Information about the audited lockfile
@@ -52,7 +52,7 @@ impl Report {
         let warnings = find_warnings(db, lockfile, settings);
 
         Self {
-            #[cfg(feature = "fetch")]
+            #[cfg(feature = "git")]
             database: DatabaseInfo::new(db),
             lockfile: LockfileInfo::new(lockfile),
             settings: settings.clone(),
@@ -108,7 +108,7 @@ impl Settings {
 }
 
 /// Information about the advisory database
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DatabaseInfo {
     /// Number of advisories in the database
@@ -124,7 +124,7 @@ pub struct DatabaseInfo {
     pub last_updated: Option<SystemTime>,
 }
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 impl DatabaseInfo {
     /// Create database information from the advisory db
     pub fn new(db: &Database) -> Self {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -2,8 +2,8 @@
 
 pub mod signature;
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 pub mod git;
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "git")]
 pub use self::git::GitRepository;

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "fetch")]
+#![cfg(feature = "git")]
 
 use cargo_lock::Lockfile;
 use once_cell::sync::Lazy;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,5 @@
 //! Integration test against the live `advisory-db` repo on GitHub
-#![cfg(feature = "fetch")]
+#![cfg(feature = "git")]
 #![warn(rust_2018_idioms, unused_qualifications)]
 
 use rustsec::{


### PR DESCRIPTION
The feature describes the git integration, so naming it "git" better describes the functionality.