### PR TITLE
Add `thread-safety` category

### DIFF
--- a/src/advisory/category.rs
+++ b/src/advisory/category.rs
@@ -48,6 +48,10 @@ pub enum Category {
     /// allowing the attacker to obtain unintended privileges.
     PrivilegeEscalation,
 
+    /// Thread safety bug, e.g. data races arising from unsafe code that
+    /// misapplies and/or misuses `Send`/`Sync`.
+    ThreadSafety,
+
     /// Other types of categories: left open-ended to add more of them in the future.
     Other(String),
 }
@@ -64,6 +68,7 @@ impl Category {
             Category::MemoryCorruption => "memory-corruption",
             Category::MemoryExposure => "memory-exposure",
             Category::PrivilegeEscalation => "privilege-escalation",
+            Category::ThreadSafety => "thread-safety",
             Category::Other(other) => other,
         }
     }
@@ -88,6 +93,7 @@ impl FromStr for Category {
             "memory-corruption" => Category::MemoryCorruption,
             "memory-exposure" => Category::MemoryExposure,
             "privilege-escalation" => Category::PrivilegeEscalation,
+            "thread-safety" => Category::ThreadSafety,
             other => Category::Other(other.to_owned()),
         })
     }


### PR DESCRIPTION
Closes https://github.com/RustSec/advisory-db/issues/511

We've had quite a few `thread-safety` vulnerabilities filed lately, so it definitely seems like it'd be good to be able to categorize them properly.

cc @Qwaz