### PR TITLE
v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.0 (2021-01-26)
+### Added
+- Advisory `references` as a URL list ([#266])
+- Support for omitting leading `[advisory]` table ([#268])
+- `thread-safety` category ([#290])
+
+### Changed
+- Rename previous `references` field to `related` ([#261])
+- Use `url` crate to parse metadata URL ([#263])
+- Bump `smol_str` to v0.1.17; MSRV 1.46+ ([#264])
+- Replace `chrono` with `humantime` ([#265])
+- Mark enums as non_exhaustive ([#267])
+- Use `SystemTime` instead of a `git::Timestamp` type ([#269])
+- Rename `fetch` Cargo feature to `git` ([#270])
+- Rename `repository::GitRepository` to `repository::git::Repository` ([#271])
+
+### Removed
+- `markdown` feature ([#262])
+
+[#261]: https://github.com/RustSec/rustsec-crate/pull/261
+[#262]: https://github.com/RustSec/rustsec-crate/pull/262
+[#263]: https://github.com/RustSec/rustsec-crate/pull/263
+[#264]: https://github.com/RustSec/rustsec-crate/pull/264
+[#265]: https://github.com/RustSec/rustsec-crate/pull/265
+[#266]: https://github.com/RustSec/rustsec-crate/pull/266
+[#267]: https://github.com/RustSec/rustsec-crate/pull/267
+[#268]: https://github.com/RustSec/rustsec-crate/pull/268
+[#269]: https://github.com/RustSec/rustsec-crate/pull/269
+[#270]: https://github.com/RustSec/rustsec-crate/pull/270
+[#271]: https://github.com/RustSec/rustsec-crate/pull/271
+[#290]: https://github.com/RustSec/rustsec-crate/pull/290
+
 ## 0.22.2 (2020-10-27)
 ### Changed
 - Revert "Refactor Advisory type handling" ([#249])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustsec"
-version = "0.23.0-pre"
+version = "0.23.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.23.0-pre" # Also update html_root_url in lib.rs when bumping this
+version     = "0.23.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.23.0-pre"
+    html_root_url = "https://docs.rs/rustsec/0.23.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Advisory `references` as a URL list ([#266])
- Support for omitting leading `[advisory]` table ([#268])
- `thread-safety` category ([#290])

### Changed
- Rename previous `references` field to `related` ([#261])
- Use `url` crate to parse metadata URL ([#263])
- Bump `smol_str` to v0.1.17; MSRV 1.46+ ([#264])
- Replace `chrono` with `humantime` ([#265])
- Mark enums as non_exhaustive ([#267])
- Use `SystemTime` instead of a `git::Timestamp` type ([#269])
- Rename `fetch` Cargo feature to `git` ([#270])
- Rename `repository::GitRepository` to `repository::git::Repository` ([#271])

### Removed
- `markdown` feature ([#262])

[#261]: https://github.com/RustSec/rustsec-crate/pull/261
[#262]: https://github.com/RustSec/rustsec-crate/pull/262
[#263]: https://github.com/RustSec/rustsec-crate/pull/263
[#264]: https://github.com/RustSec/rustsec-crate/pull/264
[#265]: https://github.com/RustSec/rustsec-crate/pull/265
[#266]: https://github.com/RustSec/rustsec-crate/pull/266
[#267]: https://github.com/RustSec/rustsec-crate/pull/267
[#268]: https://github.com/RustSec/rustsec-crate/pull/268
[#269]: https://github.com/RustSec/rustsec-crate/pull/269
[#270]: https://github.com/RustSec/rustsec-crate/pull/270
[#271]: https://github.com/RustSec/rustsec-crate/pull/271
[#290]: https://github.com/RustSec/rustsec-crate/pull/290