### PR TITLE
v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.2 (2021-03-07)
+### Changed
+- Rename advisory-db `master` branch to `main` ([#307])
+
+[#307]: https://github.com/RustSec/rustsec-crate/pull/307
+
 ## 0.23.1 (2021-02-24)
 ### Fixed
 - Parsing error on Windows ([#295])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustsec"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.23.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.23.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.23.1"
+    html_root_url = "https://docs.rs/rustsec/0.23.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Rename advisory-db `master` branch to `main` ([#307])

[#307]: https://github.com/RustSec/rustsec-crate/pull/307